### PR TITLE
Speed up for RDF generation and bug fix

### DIFF
--- a/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetRDFGenerator.java
+++ b/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetRDFGenerator.java
@@ -155,7 +155,7 @@ public class KR2RMLWorksheetRDFGenerator {
 				
 			}
 			int i=1;
-			
+			TriplesMapPlanExecutor e = new TriplesMapPlanExecutor();
 			Map<TriplesMap, TriplesMapWorkerPlan> triplesMapToWorkerPlan = new HashMap<TriplesMap, TriplesMapWorkerPlan>() ;
 			for(TriplesMap triplesMap : kr2rmlMapping.getTriplesMapList())
 			{
@@ -163,7 +163,7 @@ public class KR2RMLWorksheetRDFGenerator {
 				triplesMapToWorkerPlan.put(triplesMap, workerPlan);
 			}
 			for (Row row:rows) {
-				TriplesMapPlanExecutor e = new TriplesMapPlanExecutor();
+				
 				TriplesMapPlanGenerator g = new TriplesMapPlanGenerator(triplesMapToWorkerPlan, row, outWriter);
 				TriplesMapPlan plan = g.generatePlan(kr2rmlMapping.getAuxInfo().getTriplesMapGraph());
 				errorReport.combine(e.execute(plan));
@@ -172,7 +172,7 @@ public class KR2RMLWorksheetRDFGenerator {
 					logger.info("Done processing " + i + " rows");
 	
 			}
-			
+			e.shutdown(errorReport);
 			// Generate column provenance information if required
 			if (addColumnContextInformation) {
 				generateColumnProvenanceInformation();

--- a/src/main/java/edu/isi/karma/kr2rml/N3KR2RMLRDFWriter.java
+++ b/src/main/java/edu/isi/karma/kr2rml/N3KR2RMLRDFWriter.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.eclipse.jetty.util.ConcurrentHashSet;
 
 public class N3KR2RMLRDFWriter implements KR2RMLRDFWriter {
 
@@ -17,13 +18,13 @@ public class N3KR2RMLRDFWriter implements KR2RMLRDFWriter {
 	{
 		this.outWriter = new PrintWriter(outputStream);
 		this.uriFormatter = uriFormatter;
-		generatedTriples = new HashSet<String>();
+		generatedTriples = new ConcurrentHashSet<String>();
 	}
 	public N3KR2RMLRDFWriter(URIFormatter uriFormatter, PrintWriter writer)
 	{
 		this.outWriter =writer;
 		this.uriFormatter = uriFormatter;
-		generatedTriples = new HashSet<String>();
+		generatedTriples = new ConcurrentHashSet<String>();
 	}
 	
 	private void outputTriple(String triple)
@@ -83,7 +84,7 @@ public class N3KR2RMLRDFWriter implements KR2RMLRDFWriter {
 	public void finishRow()
 	{
 		outWriter.println("");
-		generatedTriples = new HashSet<String>();
+		generatedTriples = new ConcurrentHashSet<String>();
 	}
 	@Override
 	public void flush() {


### PR DESCRIPTION
Don’t allocate a thread pool every row, duh!
Need a concurrent hash set for the writer.
Add a timeout for really slow/errored out triples maps processing.
