### PR TITLE
Unique document per semantic label

### DIFF
--- a/karma-typer/src/main/java/edu/isi/karma/semantictypes/tfIdf/Indexer.java
+++ b/karma-typer/src/main/java/edu/isi/karma/semantictypes/tfIdf/Indexer.java
@@ -11,6 +11,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -53,6 +54,14 @@ public class Indexer {
   	doc.add(new TextField(CONTENT_FIELD_NAME, content, Field.Store.YES));
   	doc.add(new StringField(LABEL_FIELD_NAME, label, Field.Store.YES));
   	indexWriter.addDocument(doc);
+  }
+  
+  public void updateDocument(String content, String label) throws IOException 
+  {
+  	Document doc = new Document();
+  	doc.add(new TextField(CONTENT_FIELD_NAME, content, Field.Store.YES));
+  	doc.add(new StringField(LABEL_FIELD_NAME, label, Field.Store.YES));
+  	indexWriter.updateDocument(new Term(LABEL_FIELD_NAME,label), doc);
   }
   
   public void deleteDocuments() throws IOException

--- a/karma-typer/src/main/java/edu/isi/karma/semantictypes/typinghandler/LuceneBasedSTModelHandler.java
+++ b/karma-typer/src/main/java/edu/isi/karma/semantictypes/typinghandler/LuceneBasedSTModelHandler.java
@@ -12,7 +12,7 @@ import edu.isi.karma.modeling.semantictypes.ISemanticTypeModelHandler;
 import edu.isi.karma.modeling.semantictypes.SemanticTypeLabel;
 import edu.isi.karma.modeling.semantictypes.myutils.Prnt;
 import edu.isi.karma.semantictypes.tfIdf.Indexer;
-import edu.isi.karma.semantictypes.tfIdf.TopKSearcher;
+import edu.isi.karma.semantictypes.tfIdf.Searcher;
 import edu.isi.karma.webserver.ServletContextParameterMap;
 import edu.isi.karma.webserver.ServletContextParameterMap.ContextParameter;
 
@@ -148,7 +148,18 @@ public class LuceneBasedSTModelHandler implements ISemanticTypeModelHandler {
     	    sb.append(" ");
     	}
     	
-    	indexer.addDocument(sb.toString(),label);
+    	// check if semantic label already exists in index
+    	Searcher searcher = new Searcher(indexDirectory,Indexer.LABEL_FIELD_NAME);
+    	boolean labelExists = searcher.existsSemanticLabel(label);
+    	
+    	if(labelExists==true)
+    	{
+    		indexer.updateDocument(sb.toString(), label);
+    	}
+    	else
+    	{
+    		indexer.addDocument(sb.toString(),label);
+    	}
 		indexer.commit();
 		indexer.closeIndexWriter();
 	
@@ -193,7 +204,7 @@ public class LuceneBasedSTModelHandler implements ISemanticTypeModelHandler {
 		
 	    // get top-k suggestions
 	    try {
-	    	TopKSearcher predictor = new TopKSearcher(indexDirectory);
+	    	Searcher predictor = new Searcher(indexDirectory,Indexer.CONTENT_FIELD_NAME);
 			return predictor.getTopK(numPredictions, sb.toString());
 		} catch (ParseException | IOException e) {
 			e.printStackTrace();


### PR DESCRIPTION
Ensured that document corresponding to existing semantic label is updated and not that a new one is created
