### PR TITLE
Update OracleUtil.java

### DIFF
--- a/karma-jdbc/src/main/java/edu/isi/karma/util/OracleUtil.java
+++ b/karma-jdbc/src/main/java/edu/isi/karma/util/OracleUtil.java
@@ -121,7 +121,7 @@ public class OracleUtil extends AbstractJDBCUtil {
 
 	@Override
 	public String escapeTablename(String name) {
-		return "`" + name + "`";
+		return "\"" + name + "\"";
 	}
 	
 	@Override


### PR DESCRIPTION
#169 
escaping tablenames with backticks does not work in oracle, requires double quotes