### PR TITLE
"toString()" should never be called on a String object

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Interpretor.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Interpretor.java
@@ -21,7 +21,7 @@ public class Interpretor {
 									.getParameterValue(ContextParameter.PYTHON_SCRIPTS_DIRECTORY);
 		
 									;
-		if(dirpathString == null || dirpathString.toString().length() <= 1) {
+		if(dirpathString == null || dirpathString.length() <= 1) {
 			dirpathString = "../karma-web/src/main/webapp/resources/pythonCleaningscripts";
 		}
 		logger.info("Setting Python Scripts Directory for karma-cleaning: "

--- a/karma-commands/commands-publish/src/main/java/edu/isi/karma/model/serialization/DataSourcePublisher.java
+++ b/karma-commands/commands-publish/src/main/java/edu/isi/karma/model/serialization/DataSourcePublisher.java
@@ -144,7 +144,7 @@ public class DataSourcePublisher extends SourcePublisher {
 
 		if (this.source.getVariables() != null)
 		for (int i = 0; i < this.source.getVariables().size(); i++) {
-			Resource my_variable = model.createResource(baseNS + this.source.getVariables().get(i).toString());
+			Resource my_variable = model.createResource(baseNS + this.source.getVariables().get(i));
 			my_variable.addProperty(rdf_type, variavle_resource);
 			my_source.addProperty(has_variable, my_variable);
 		}

--- a/karma-common/src/main/java/edu/isi/karma/config/ModelingConfiguration.java
+++ b/karma-common/src/main/java/edu/isi/karma/config/ModelingConfiguration.java
@@ -82,7 +82,7 @@ public class ModelingConfiguration {
 	private Boolean showModelsWithoutMatching;
 	private String defaultProperty = null;
 	
-	private final String newLine = System.getProperty("line.separator").toString();
+	private final String newLine = System.getProperty("line.separator");
 	
 	private String defaultModelingProperties = 
 			"##########################################################################################" + newLine + 

--- a/karma-common/src/main/java/edu/isi/karma/config/UIConfiguration.java
+++ b/karma-common/src/main/java/edu/isi/karma/config/UIConfiguration.java
@@ -32,7 +32,7 @@ public class UIConfiguration {
 	
 	private static Logger logger = LoggerFactory.getLogger(UIConfiguration.class);
 	
-	private static final String newLine = System.getProperty("line.separator").toString();
+	private static final String newLine = System.getProperty("line.separator");
 	
 	private static String propGoogleEarthEnabled = "google.earth.enabled=true";
 	private static String propMaxLoadedClasses = "max.loaded.classes=-1";

--- a/karma-common/src/main/java/edu/isi/karma/controller/command/service/ServiceTableUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/command/service/ServiceTableUtil.java
@@ -154,7 +154,7 @@ public class ServiceTableUtil {
 				}
 				
 				for (String id: oldHNodeIdList) {
-					row.setValue(id, currentRow.get(id).toString(), factory);
+					row.setValue(id, currentRow.get(id), factory);
 				}
 				
 			}

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/KR2RMLConfiguration.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/KR2RMLConfiguration.java
@@ -19,7 +19,7 @@ import edu.isi.karma.webserver.ServletContextParameterMap.ContextParameter;
 public class KR2RMLConfiguration {
 	private static final Logger logger = LoggerFactory.getLogger(KR2RMLConfiguration.class);
 	private static Properties properties;
-	private static final String newLine = System.getProperty("line.separator").toString();
+	private static final String newLine = System.getProperty("line.separator");
 	private static String defaultKR2RMLProperties = "template.terms.no.minimum.for.blank.nodes=false"+ newLine;
 	
 	// WK-226 Adds the ability to generate blank nodes with out satisfying any column terms

--- a/karma-common/src/main/java/edu/isi/karma/service/json/JsonManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/service/json/JsonManager.java
@@ -159,7 +159,7 @@ public class JsonManager {
 		for (int i = 0; i < srcColumns.size(); i++) {
 			for (int j = 0; j < srcColumns.get(i).size(); j++)
 			{
-				colName = srcColumns.get(i).get(j).toString();
+				colName = srcColumns.get(i).get(j);
 				if (columns.indexOf(colName) == -1)
 					columns.add(colName);
 			}
@@ -176,7 +176,7 @@ public class JsonManager {
 				rawValues = srcValues.get(i).get(j);
 				
 				for (int k = 0; k < columns.size(); k++) {
-					int index = rawNames.indexOf(columns.get(k).toString());
+					int index = rawNames.indexOf(columns.get(k));
 					if (index == -1)
 						singleValue = null;
 					else
@@ -197,7 +197,7 @@ public class JsonManager {
 		for (int i = 0; i < srcColumns.size(); i++) {
 			for (int j = 0; j < srcColumns.get(i).size(); j++)
 			{
-				colName = srcColumns.get(i).get(j).toString();
+				colName = srcColumns.get(i).get(j);
 				if (columns.indexOf(colName) == -1) {
 					columns.add(colName);
 					types.add(srcTypes.get(i).get(j));
@@ -216,7 +216,7 @@ public class JsonManager {
 				rawValues = srcValues.get(i).get(j);
 				
 				for (int k = 0; k < columns.size(); k++) {
-					int index = rawNames.indexOf(columns.get(k).toString());
+					int index = rawNames.indexOf(columns.get(k));
 					if (index == -1)
 //						singleValue = null;
 						singleValue = "";

--- a/karma-common/src/main/java/edu/isi/karma/util/JSONLDUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/JSONLDUtil.java
@@ -19,7 +19,7 @@ public class JSONLDUtil {
 		while(iterator.hasNext())
 		{
 
-			String value = iterator.next().toString();
+			String value = iterator.next();
 			JSONObject object = new JSONObject(value);
 			accumulatorObject = mergeJSONObjects(accumulatorObject, object);
 		}

--- a/karma-mr/src/main/java/edu/isi/karma/mapreduce/driver/IdentityN3Mapper.java
+++ b/karma-mr/src/main/java/edu/isi/karma/mapreduce/driver/IdentityN3Mapper.java
@@ -16,7 +16,7 @@ public class IdentityN3Mapper extends Mapper<Writable, Text, Text, Text> {
 	public void map(Writable key, Text value, Context context) throws IOException, InterruptedException {
 		try {
 			String valueString = value.toString();
-			String subject = valueString.toString().substring(0, valueString.indexOf(' '));
+			String subject = valueString.substring(0, valueString.indexOf(' '));
 			outputKeyText.set(subject);
 			context.write(outputKeyText, value);
 		}catch(Exception e) {

--- a/karma-offline/src/main/java/edu/isi/karma/rdf/BaseRDFImpl.java
+++ b/karma-offline/src/main/java/edu/isi/karma/rdf/BaseRDFImpl.java
@@ -111,13 +111,13 @@ public abstract class BaseRDFImpl implements Serializable {
     public String mapResult(String key, String value) throws IOException,
             InterruptedException {
 
-        String contents = value.toString();
+        String contents = value;
 
-        JSONObject jMatchedKarmaConfig = matchKeyToKarmaConfig(key.toString());
+        JSONObject jMatchedKarmaConfig = matchKeyToKarmaConfig(key);
         String results = "";
         if (contents.trim() != ""){
 
-            LOG.debug(key.toString() + " started");
+            LOG.debug(key + " started");
             if(hasHeader && header ==null)
             {
                 header=contents;
@@ -154,7 +154,7 @@ public abstract class BaseRDFImpl implements Serializable {
             else{
                 results = checkResultsAndWriteToContext(key,value,"model");
             }
-            LOG.debug(key.toString() + " finished");
+            LOG.debug(key + " finished");
         }
         return results;
     }
@@ -228,8 +228,8 @@ public abstract class BaseRDFImpl implements Serializable {
 
     protected String generateJSONLD(String key, String value, String modelName)
     {
-        String filename = key.toString();
-        String contents = value.toString();
+        String filename = key;
+        String contents = value;
         StringWriter sw = new StringWriter();
 
         String results = "";

--- a/karma-spark/src/main/java/edu/isi/karma/spark/KarmaDriver.java
+++ b/karma-spark/src/main/java/edu/isi/karma/spark/KarmaDriver.java
@@ -256,7 +256,7 @@ public class KarmaDriver {
 	    for (@SuppressWarnings("unchecked")
 		Iterator<String> keysIterator = properties.keys(); keysIterator.hasNext(); ) {
 			String objPropertyName = keysIterator.next();
-			String propertyName = objPropertyName.toString();
+			String propertyName = objPropertyName;
 			String value = properties.getString(propertyName);
 			logger.info("Set " + propertyName + "=" + value);
 			prop.setProperty(propertyName, value);

--- a/karma-web/src/main/java/edu/isi/karma/webserver/LinkedApiServiceHandler.java
+++ b/karma-web/src/main/java/edu/isi/karma/webserver/LinkedApiServiceHandler.java
@@ -138,9 +138,9 @@ public class LinkedApiServiceHandler extends HttpServlet {
 		logger.debug("Resource: " + resource);
 
 		ResourceType resourceType = ResourceType.Service;
-		if (resource != null && resource.trim().toString().equalsIgnoreCase("input"))
+		if (resource != null && resource.trim().equalsIgnoreCase("input"))
 			resourceType = ResourceType.Input;
-		if (resource != null && resource.trim().toString().equalsIgnoreCase("output"))
+		if (resource != null && resource.trim().equalsIgnoreCase("output"))
 			resourceType = ResourceType.Output;
 
 		String contextId = ContextParametersRegistry.getInstance().getDefault().getId();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1858 - “"toString()" should never be called on a String object”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1858
Please let me know if you have any questions.
Ayman Abdelghany.