### PR TITLE
 "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Correctness/FormatFunc.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Correctness/FormatFunc.java
@@ -2,6 +2,7 @@ package edu.isi.karma.cleaning.Correctness;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import edu.isi.karma.cleaning.UtilTools;
 
@@ -46,9 +47,9 @@ public class FormatFunc implements VerificationFunc {
 			}
 		}
 		// find the means 
-		for(String key: tmp.keySet())
+		for(Map.Entry<String, ArrayList<TransRecord>> stringArrayListEntry : tmp.entrySet())
 		{
-			ArrayList<TransRecord> tdata = tmp.get(key);
+			ArrayList<TransRecord> tdata = stringArrayListEntry.getValue();
 			if(tdata.size() > 0 || tdata.get(0).features.length > 0)
 			{
 				ArrayList<double[]> tcl = new ArrayList<double[]>();
@@ -58,7 +59,7 @@ public class FormatFunc implements VerificationFunc {
 				}
 				double[] tmean = UtilTools.sum(tcl);
 				tmean = UtilTools.produce(1.0/tdata.size(), tmean);
-				cmeans.put(key, tmean);
+				cmeans.put(stringArrayListEntry.getKey(), tmean);
 				// find the max distances
 				// strictly bigger or smaller than [mean-3*delta, mean+3*delta]
 				double d_mean = 0;
@@ -74,7 +75,7 @@ public class FormatFunc implements VerificationFunc {
 				}
 				d_mu = Math.sqrt(d_mu/tdata.size());
 				double[] x = {d_mean,d_mu};
-				mean_var.put(key, x);
+				mean_var.put(stringArrayListEntry.getKey(), x);
 			}
 		}
 		

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/DataPreProcessor.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/DataPreProcessor.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Vector;
 
@@ -61,8 +62,8 @@ public class DataPreProcessor {
 				}
 			}
 		}
-		for (String key : xHashMap.keySet()) {
-			double[] value = xHashMap.get(key);
+		for (Entry<String, double[]> stringEntry : xHashMap.entrySet()) {
+			double[] value = stringEntry.getValue();
 			for (int i = 0; i < value.length; i++) {
 				if (maxvals[i] > minvals[i]) {
 					double tmpval = (value[i] - minvals[i])/(maxvals[i] - minvals[i]);
@@ -71,7 +72,7 @@ public class DataPreProcessor {
 					value[i] = 0;
 				}
 			}
-			xHashMap.put(key, value);
+			xHashMap.put(stringEntry.getKey(), value);
 		}
 	}
 	public HashMap<String, double[]> vectorize(Collection<String> data) {
@@ -91,8 +92,8 @@ public class DataPreProcessor {
 		// build singature for each feature
 		for (int i = 0; i < rfs.getFeatureNames().size(); i++) {
 			String sg = "";
-			for (String key : data.keySet()) {
-				sg += data.get(key)[i]+"\n";
+			for (Entry<String, double[]> stringEntry : data.entrySet()) {
+				sg += stringEntry.getValue()[i]+"\n";
 			}
 			if (signs.contains(sg)) {
 				toRemove.add(i);

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleCluster.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleCluster.java
@@ -75,9 +75,9 @@ public class ExampleCluster {
 			for (Vector<String[]> group : constraints) {
 				xHashSet2.add(constraintKey(group));
 			}
-			for (String k : xHashMap1.keySet()) {
-				if (!xHashSet2.contains(k)) {
-					constraints.add(xHashMap1.get(k));
+			for (Map.Entry<String, Vector<String[]>> stringVectorEntry : xHashMap1.entrySet()) {
+				if (!xHashSet2.contains(stringVectorEntry.getKey())) {
+					constraints.add(stringVectorEntry.getValue());
 				}
 			}
 			// update islegal ds
@@ -145,8 +145,8 @@ public class ExampleCluster {
 				for (int j = i + 1; j < pars.size(); j++) {
 					String key = getStringKey(pars.get(i), pars.get(j));
 					boolean good = true;
-					for (String k : legalParitions.keySet()) {
-						if (!legalParitions.get(k) && key.indexOf(k) != -1) {
+					for (Map.Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+						if (!stringBooleanEntry.getValue() && key.indexOf(stringBooleanEntry.getKey()) != -1) {
 							good = false;
 							break;
 						}
@@ -236,8 +236,8 @@ public class ExampleCluster {
 				for (int j = i + 1; j < pars.size(); j++) {
 					String key = getStringKey(pars.get(i), pars.get(j));
 					boolean good = true;
-					for (String k : legalParitions.keySet()) {
-						if (!legalParitions.get(k) && key.indexOf(k) != -1) {
+					for (Map.Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+						if (!stringBooleanEntry.getValue() && key.indexOf(stringBooleanEntry.getKey()) != -1) {
 							good = false;
 							break;
 						}
@@ -365,21 +365,21 @@ public class ExampleCluster {
 			 * p_index.orgUnlabeledData.add(val); }
 			 */
 		}
-		for (Partition key : testResult.keySet()) {
-			Map<?, ?> dicttmp = UtilTools.sortByComparator(testResult.get(key));
+		for (Map.Entry<Partition, HashMap<String, Double>> partitionHashMapEntry : testResult.entrySet()) {
+			Map<?, ?> dicttmp = UtilTools.sortByComparator(partitionHashMapEntry.getValue());
 			/** print unlabeled data **/
 			// System.out.println("Partition: " + key.label);
 			// ProgTracker.printUnlabeledData(dicttmp);
 			/****/
 			int cnt = 0;
 			for (Object xkey : dicttmp.keySet()) {
-				if (cnt < unlabelDataAmount * key.orgNodes.size()) {
+				if (cnt < unlabelDataAmount * partitionHashMapEntry.getKey().orgNodes.size()) {
 					if (exampleInputs.contains((String) xkey))// exclude
 																// examples from
 																// unlabeled
 																// data
 						continue;
-					key.orgUnlabeledData.add((String) xkey);
+					partitionHashMapEntry.getKey().orgUnlabeledData.add((String) xkey);
 					cnt++;
 				} else {
 					break;
@@ -443,8 +443,8 @@ public class ExampleCluster {
 			}
 			// calculate instance array
 			ArrayList<double[]> instances = new ArrayList<double[]>();
-			for (String s : string2Vector.keySet()) {
-				double[] elem = string2Vector.get(s);
+			for (Map.Entry<String, double[]> stringEntry : string2Vector.entrySet()) {
+				double[] elem = stringEntry.getValue();
 				instances.add(elem);
 			}
 			// calculate constraint array
@@ -524,8 +524,8 @@ public class ExampleCluster {
 
 	public double getCompScore(Partition a, Partition b, Vector<Partition> pars) {
 		String key = getStringKey(a, b);
-		for (String ekey : legalParitions.keySet()) {
-			if (key.indexOf(ekey) != -1 && !legalParitions.get(ekey)) {
+		for (Map.Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+			if (key.indexOf(stringBooleanEntry.getKey()) != -1 && !stringBooleanEntry.getValue()) {
 				return Double.MAX_VALUE;
 			}
 		}
@@ -596,10 +596,10 @@ public class ExampleCluster {
 			return legalParitions.get(key);
 		}
 		// test whether its subset fails
-		for (String k : legalParitions.keySet()) {
-			if (!legalParitions.get(k)) // false
+		for (Map.Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+			if (!stringBooleanEntry.getValue()) // false
 			{
-				if (iscovered(key, k)) {
+				if (iscovered(key, stringBooleanEntry.getKey())) {
 					return false;
 				}
 			}
@@ -629,10 +629,10 @@ public class ExampleCluster {
 			return legalParitions.get(key);
 		}
 		// test whether its subset fails
-		for (String k : legalParitions.keySet()) {
-			if (!legalParitions.get(k)) // false
+		for (Map.Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+			if (!stringBooleanEntry.getValue()) // false
 			{
-				if (key.indexOf(k) != -1) {
+				if (key.indexOf(stringBooleanEntry.getKey()) != -1) {
 					return false;
 				}
 			}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
@@ -24,6 +24,7 @@ package edu.isi.karma.cleaning;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.QuestionableRecord.OutlierDetector;
@@ -78,8 +79,8 @@ public class ExampleSelection {
 
 	public Vector<String[]> getOrgTarPair(HashMap<String, String[]> exps) {
 		Vector<String[]> result = new Vector<String[]>();
-		for (String key : exps.keySet()) {
-			String[] record = exps.get(key);
+		for (Map.Entry<String, String[]> stringEntry : exps.entrySet()) {
+			String[] record = stringEntry.getValue();
 			String[] tmp = { record[0], record[1] };
 			result.add(tmp);
 		}
@@ -101,23 +102,22 @@ public class ExampleSelection {
 			out.buildMeanVector(examples, dictionary);
 		}
 		Ruler ruler = new Ruler();
-		for (String keyString : exps.keySet()) {
-			String e = exps.get(keyString)[0];
+		for (Map.Entry<String, String[]> stringEntry : exps.entrySet()) {
+			String e = stringEntry.getValue()[0];
 			ruler.setNewInput(e);
-			org.put(keyString, ruler.vec);
+			org.put(stringEntry.getKey(), ruler.vec);
 			if (way >= 6) {
-				String raw = exps.get(keyString)[0];
-				String[] pair = { raw, exps.get(keyString)[2] };
-				if (testdata.containsKey(exps.get(keyString)[3])) {
-					HashMap<String, String[]> xelem = testdata.get(exps
-							.get(keyString)[3]);
-					if (!xelem.containsKey(keyString)) {
-						xelem.put(keyString, pair);
+				String raw = stringEntry.getValue()[0];
+				String[] pair = { raw, stringEntry.getValue()[2] };
+				if (testdata.containsKey(stringEntry.getValue()[3])) {
+					HashMap<String, String[]> xelem = testdata.get(stringEntry.getValue()[3]);
+					if (!xelem.containsKey(stringEntry.getKey())) {
+						xelem.put(stringEntry.getKey(), pair);
 					}
 				} else {
 					HashMap<String, String[]> vstr = new HashMap<String, String[]>();
-					vstr.put(keyString, pair);
-					testdata.put(exps.get(keyString)[3], vstr);
+					vstr.put(stringEntry.getKey(), pair);
+					testdata.put(stringEntry.getValue()[3], vstr);
 				}
 			}
 		}
@@ -194,10 +194,10 @@ public class ExampleSelection {
 			firsttime = false;
 			return raw.keySet().iterator().next();
 		}
-		for (String key : raw.keySet()) {
+		for (Map.Entry<String, String[]> stringEntry : raw.entrySet()) {
 
-			if (raw.get(key)[2].indexOf("_FATAL_ERROR_") != -1) {
-				return key;
+			if (stringEntry.getValue()[2].indexOf("_FATAL_ERROR_") != -1) {
+				return stringEntry.getKey();
 			}
 		}
 		return this.way2();
@@ -210,9 +210,9 @@ public class ExampleSelection {
 			return this.way2();
 		}
 		Vector<String> examples = new Vector<String>();
-		for (String key : raw.keySet()) {
+		for (Map.Entry<String, String[]> stringEntry : raw.entrySet()) {
 			int cnt = 0;
-			String[] tmp = raw.get(key)[2]
+			String[] tmp = stringEntry.getValue()[2]
 					.split("((?<=_\\d_FATAL_ERROR_)|(?=_\\d_FATAL_ERROR_))");
 
 			for (String tmpstring : tmp) {
@@ -226,10 +226,10 @@ public class ExampleSelection {
 			if (cnt > max) {
 				max = cnt;
 				examples.clear();
-				examples.add(key);
+				examples.add(stringEntry.getKey());
 			}
 			if (cnt == max && max > 1) {
-				examples.add(key);
+				examples.add(stringEntry.getKey());
 			}
 		}
 		// if now _FATAL_ERROR_ detected use outlier detection
@@ -260,9 +260,9 @@ public class ExampleSelection {
 			return this.way2();
 		}
 		Vector<String> examples = new Vector<String>();
-		for (String key : raw.keySet()) {
+		for (Map.Entry<String, String[]> stringEntry : raw.entrySet()) {
 			int cnt = 0;
-			String[] tmp = raw.get(key)[2]
+			String[] tmp = stringEntry.getValue()[2]
 					.split("((?<=_\\d_FATAL_ERROR_)|(?=_\\d_FATAL_ERROR_))");
 			for (String tmpstring : tmp) {
 				int errnum = 0;
@@ -275,10 +275,10 @@ public class ExampleSelection {
 			if (cnt > max) {
 				max = cnt;
 				examples.clear();
-				examples.add(key);
+				examples.add(stringEntry.getKey());
 			}
 			if (cnt == max && max > 1) {
-				examples.add(key);
+				examples.add(stringEntry.getKey());
 			}
 		}
 		// if no _FATAL_ERROR_ detected use outlier detection
@@ -286,9 +286,9 @@ public class ExampleSelection {
 			isDetectingQuestionableRecord = true;
 			String row = "";
 			double tmax = -1;
-			for (String key : this.testdata.keySet()) {
-				String trowid = out.getOutliers(testdata.get(key),
-						out.rVectors.get(key), tmax, dictionary);
+			for (Map.Entry<String, HashMap<String, String[]>> stringHashMapEntry : this.testdata.entrySet()) {
+				String trowid = out.getOutliers(stringHashMapEntry.getValue(),
+						out.rVectors.get(stringHashMapEntry.getKey()), tmax, dictionary);
 				tmax = out.currentMax;
 				if (trowid.length() > 0) {
 					row = trowid;
@@ -364,9 +364,9 @@ public class ExampleSelection {
 	public void printdata() {
 		String s1 = "";
 		String s2 = "";
-		for (String key : this.testdata.keySet()) {
-			HashMap<String, String[]> r = testdata.get(key);
-			s1 += "partition " + key + "\n";
+		for (Map.Entry<String, HashMap<String, String[]>> stringHashMapEntry : this.testdata.entrySet()) {
+			HashMap<String, String[]> r = stringHashMapEntry.getValue();
+			s1 += "partition " + stringHashMapEntry.getKey() + "\n";
 			for (String[] elem : r.values()) {
 				s1 += Arrays.toString(elem) + "\n";
 			}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/OptimizePartition.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/OptimizePartition.java
@@ -207,10 +207,10 @@ public class OptimizePartition {
 			return legalParitions.get(key);
 		}
 		// test whether its subset fails
-		for (String k : legalParitions.keySet()) {
-			if (!legalParitions.get(k)) // false
+		for (Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+			if (!stringBooleanEntry.getValue()) // false
 			{
-				if (key.indexOf(k) != -1) {
+				if (key.indexOf(stringBooleanEntry.getKey()) != -1) {
 					return false;
 				}
 			}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Position.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Position.java
@@ -3,6 +3,7 @@ package edu.isi.karma.cleaning;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -391,19 +392,19 @@ public class Position implements GrammarTreeNode {
 		String reString3 = "";
 		SortedMap<Double, Vector<String>> sortedMap = new TreeMap<Double, Vector<String>>();
 		String negString = "";
-		for (String a : lMap.keySet()) {
-			for (String b : rMap.keySet()) {
-				if (a.compareTo(b) == 0 && a.compareTo("ANY") == 0)
+		for (Map.Entry<String, Double> stringDoubleEntry : lMap.entrySet()) {
+			for (Map.Entry<String, Double> stringDoubleEntry1 : rMap.entrySet()) {
+				if (stringDoubleEntry.getKey().compareTo(stringDoubleEntry1.getKey()) == 0 && stringDoubleEntry.getKey().compareTo("ANY") == 0)
 					continue;
-				Double key = lMap.get(a) + rMap.get(b);
+				Double key = stringDoubleEntry.getValue() + stringDoubleEntry1.getValue();
 				reString = String.format(
-						"indexOf(value,\'%s\',\'%s\',1*counter)", a, b);
+						"indexOf(value,\'%s\',\'%s\',1*counter)", stringDoubleEntry.getKey(), stringDoubleEntry1.getKey());
 				reString2 = String.format(
-						"indexOf(value,\'%s\',\'%s\',2*counter)", a, b);
+						"indexOf(value,\'%s\',\'%s\',2*counter)", stringDoubleEntry.getKey(), stringDoubleEntry1.getKey());
 				reString3 = String.format(
-						"indexOf(value,\'%s\',\'%s\',3*counter)", a, b);
+						"indexOf(value,\'%s\',\'%s\',3*counter)", stringDoubleEntry.getKey(), stringDoubleEntry1.getKey());
 				negString = String.format(
-						"indexOf(value,\'%s\',\'%s\',-1*counter)", a, b);
+						"indexOf(value,\'%s\',\'%s\',-1*counter)", stringDoubleEntry.getKey(), stringDoubleEntry1.getKey());
 				if (sortedMap.containsKey(key)) {
 					sortedMap.get(key).add(reString);
 					sortedMap.get(key).add(reString2);

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgSynthesis.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgSynthesis.java
@@ -3,6 +3,7 @@ package edu.isi.karma.cleaning;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Vector;
 
 import org.perf4j.StopWatch;
@@ -155,10 +156,10 @@ public class ProgSynthesis {
 			return legalParitions.get(key);
 		}
 		// test whether its subset fails
-		for (String k : legalParitions.keySet()) {
-			if (!legalParitions.get(k)) // false
+		for (Map.Entry<String, Boolean> stringBooleanEntry : legalParitions.entrySet()) {
+			if (!stringBooleanEntry.getValue()) // false
 			{
-				if (key.indexOf(k) != -1) {
+				if (key.indexOf(stringBooleanEntry.getKey()) != -1) {
 					return false;
 				}
 			}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgTracker.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgTracker.java
@@ -29,8 +29,8 @@ public class ProgTracker {
 
 	@SuppressWarnings("rawtypes")
 	public static void printUnlabeledData(Map dicttmp) {
-		for (Object xkey : dicttmp.keySet()) {
-			System.out.println(String.format("Entry: %s,%f", xkey,dicttmp.get(xkey)));
+		for (Object o : dicttmp.entrySet()) {
+			System.out.println(String.format("Entry: %s,%f", ((Map.Entry) o).getKey(), ((Map.Entry) o).getValue()));
 		}
 	}
 }

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgramAdaptator.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgramAdaptator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Vector;
 
 import org.perf4j.StopWatch;
@@ -459,8 +460,8 @@ public class ProgramAdaptator {
 			HashMap<Integer, Template> tmpts = wSpace.traceline;
 			Vector<GrammarTreeNode> groundTruth = pat.groundTruth;
 			ArrayList<Path> allPaths = new ArrayList<Path>();
-			for (Integer len : tmpts.keySet()) {
-				Vector<GrammarTreeNode> tBody = tmpts.get(len).body;
+			for (Map.Entry<Integer, Template> integerTemplateEntry : tmpts.entrySet()) {
+				Vector<GrammarTreeNode> tBody = integerTemplateEntry.getValue().body;
 				ArrayList<Path> paths = extractPath(tBody, tarStrings, tarSegs, evalNewExp);
 				for(Path p: paths)
 				{
@@ -698,13 +699,13 @@ public class ProgramAdaptator {
 		String prog = "";
 		//most compatible program
 		int msize = -1;
-		for(String key: exp2Prog.keySet())
+		for(Map.Entry<String, String> stringStringEntry : exp2Prog.entrySet())
 		{
-			int sz = key.split("\\*").length;
-			if(sz > msize &&UtilTools.iscovered(key, subkey))
+			int sz = stringStringEntry.getKey().split("\\*").length;
+			if(sz > msize &&UtilTools.iscovered(stringStringEntry.getKey(), subkey))
 			{
 				msize = sz;
-				prog = exp2Prog.get(key);
+				prog = stringStringEntry.getValue();
 			}
 		}
 		return prog;

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgramRule.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgramRule.java
@@ -1,6 +1,7 @@
 package edu.isi.karma.cleaning;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class ProgramRule {
 	public HashMap<String, InterpreterType> rules = new HashMap<String, InterpreterType>();
@@ -80,8 +81,8 @@ public class ProgramRule {
 
 	public String toString() {
 		String res = "";
-		for (String key : strRules.keySet()) {
-			res += String.format("%s:%s\n", key, strRules.get(key));
+		for (Map.Entry<String, String> stringStringEntry : strRules.entrySet()) {
+			res += String.format("%s:%s\n", stringStringEntry.getKey(), stringStringEntry.getValue());
 		}
 		return res;
 	}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/QuestionableRecord/OutlierDetector.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/QuestionableRecord/OutlierDetector.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Vector;
 
@@ -137,8 +138,8 @@ public class OutlierDetector {
 		this.currentMax = -1;
 		if (data == null)
 			return;
-		for (String key : data.keySet()) {
-			Vector<String[]> vs = data.get(key);
+		for (Entry<String, Vector<String[]>> stringVectorEntry : data.entrySet()) {
+			Vector<String[]> vs = stringVectorEntry.getValue();
 			FeatureVector fVector = new FeatureVector(dict);
 			double[] dvec = new double[fVector.size()];
 			for (int i = 0; i < dvec.length; i++) {
@@ -155,7 +156,7 @@ public class OutlierDetector {
 			for (int i = 0; i < dvec.length; i++) {
 				dvec[i] = dvec[i] * 1.0 / vs.size();
 			}
-			rVectors.put(key, dvec);
+			rVectors.put(stringVectorEntry.getKey(), dvec);
 		}
 	}
 

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ClassifierRefiner.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ClassifierRefiner.java
@@ -3,6 +3,7 @@ package edu.isi.karma.cleaning.Research;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import edu.isi.karma.cleaning.Program;
 // input: classifier, results for each record
@@ -26,9 +27,9 @@ public class ClassifierRefiner {
 	//auxiliary functions
 	public void clusterUdata()
 	{
-		for(String row:uData.keySet())
+		for(Map.Entry<String, HashMap<String, String>> stringHashMapEntry : uData.entrySet())
 		{
-			HashMap<String, String> dict = uData.get(row);
+			HashMap<String, String> dict = stringHashMapEntry.getValue();
 			String ckey = dict.get("class");
 			String org = dict.get("Org");
 			if(clusters.containsKey(ckey))
@@ -43,12 +44,12 @@ public class ClassifierRefiner {
 			}
 		}
 		//tostring
-		for(String key:clusters.keySet())
+		for(Map.Entry<String, ArrayList<String>> stringArrayListEntry : clusters.entrySet())
 		{
-			System.out.println("====="+key+"=======");
-			for(String val:clusters.get(key))
+			System.out.println("====="+ stringArrayListEntry.getKey() +"=======");
+			for(String val: stringArrayListEntry.getValue())
 			{
-				System.out.println(String.format("\"%s\", \"%s\"", val,key));
+				System.out.println(String.format("\"%s\", \"%s\"", val, stringArrayListEntry.getKey()));
 			}
 		}
 	}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/DataCollection.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/DataCollection.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.MyLogger;
@@ -95,8 +96,8 @@ public class DataCollection {
 		MyLogger.logsth("============Summary Information===========\n"
 				+ this.getDate() + "\n");
 		MyLogger.logsth(DataCollection.config + "\n");
-		for (String key : stats.keySet()) {
-			Double[] value = stats.get(key);
+		for (Map.Entry<String, Double[]> stringEntry : stats.entrySet()) {
+			Double[] value = stringEntry.getValue();
 			Double cnt = value[6];
 			value[1] = value[0] * 1.0 / cnt;
 			value[3] = value[2] * 1.0 / cnt;
@@ -104,10 +105,10 @@ public class DataCollection {
 			value[10] = value[10]*1.0 / cnt;
 			// long the final stats
 			String lineString = "";
-			if(this.succeededFiles.contains(key))
-				lineString = String.format("%s,T_learn,%f,avg_learn,%f,T_gen,%f,avg_gen,%f,T_exec,%f,avg_exec,%f,exp,%f,constraint,%f,clfacc,%f, parNum, %f\n",key,value[0],value[1],value[2],value[3],value[4],value[5],value[6],value[7],value[10],value[11]);
+			if(this.succeededFiles.contains(stringEntry.getKey()))
+				lineString = String.format("%s,T_learn,%f,avg_learn,%f,T_gen,%f,avg_gen,%f,T_exec,%f,avg_exec,%f,exp,%f,constraint,%f,clfacc,%f, parNum, %f\n", stringEntry.getKey(),value[0],value[1],value[2],value[3],value[4],value[5],value[6],value[7],value[10],value[11]);
 			else {
-				lineString = String.format("%s_failed,T_learn,%f,avg_learn,%f,T_gen,%f,avg_gen,%f,T_exec,%f,avg_exec,%f,exp,%f,constraint,%f,clfacc,%f,parNum,%f\n",key,value[0],value[1],value[2],value[3],value[4],value[5],value[6],value[7],value[10],value[11]);
+				lineString = String.format("%s_failed,T_learn,%f,avg_learn,%f,T_gen,%f,avg_gen,%f,T_exec,%f,avg_exec,%f,exp,%f,constraint,%f,clfacc,%f,parNum,%f\n", stringEntry.getKey(),value[0],value[1],value[2],value[3],value[4],value[5],value[6],value[7],value[10],value[11]);
 			}
 			MyLogger.logsth(lineString);
 		}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/Prober.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/Prober.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.Partition;
@@ -60,9 +61,9 @@ public class Prober {
 			res += String.format("%s   %s\n", x[0], x[1]);
 		}
 		
-		for(String k:dics.keySet())
+		for(Map.Entry<String, String> stringStringEntry : dics.entrySet())
 		{
-			System.out.println("dict: "+String.format("%s, %s", k, dics.get(k)));
+			System.out.println("dict: "+String.format("%s, %s", stringStringEntry.getKey(), stringStringEntry.getValue()));
 		}
 		for(Patcher p:errNodes)
 		{

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/RecordDistiller.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/RecordDistiller.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Vector;
 
 import au.com.bytecode.opencsv.CSVReader;
@@ -86,11 +87,11 @@ public class RecordDistiller {
 	// identify the anchor tokens
 	public void idenAnchor(int total) {
 		Vector<String> dels = new Vector<String>();
-		for (String a : anchors.keySet()) {
-			int count = anchors.get(a).count;
+		for (Map.Entry<String, Anchor> stringAnchorEntry : anchors.entrySet()) {
+			int count = stringAnchorEntry.getValue().count;
 			// if an anchor appears in more 10% records, it's a valid anchor
 			if (count * 1.0 / total < 0.1) {
-				dels.add(a);
+				dels.add(stringAnchorEntry.getKey());
 			}
 		}
 		for (String s : dels) {
@@ -139,17 +140,17 @@ public class RecordDistiller {
 		}
 		// generate candiate set
 		HashSet<String> result = new HashSet<String>();
-		for (String cxt : lcxt2ids.keySet()) {
-			if (lcxt2ids.get(cxt).size() != 0) {
-				String idString = lcxt2ids.get(cxt).get(0);
+		for (Map.Entry<String, Vector<String>> stringVectorEntry : lcxt2ids.entrySet()) {
+			if (stringVectorEntry.getValue().size() != 0) {
+				String idString = stringVectorEntry.getValue().get(0);
 				if (!result.contains(idString)) {
 					result.add(idString);
 				}
 			}
 		}
-		for (String cxt : rcxt2ids.keySet()) {
-			if (rcxt2ids.get(cxt).size() != 0) {
-				String idString = rcxt2ids.get(cxt).get(0);
+		for (Map.Entry<String, Vector<String>> stringVectorEntry : rcxt2ids.entrySet()) {
+			if (stringVectorEntry.getValue().size() != 0) {
+				String idString = stringVectorEntry.getValue().get(0);
 				if (!result.contains(idString)) {
 					result.add(idString);
 				}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/Test.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/Test.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import au.com.bytecode.opencsv.CSVReader;
@@ -1023,9 +1024,9 @@ public class Test {
 
 	public static void hashResultPrint(HashMap<String, Vector<String>> res) {
 		String s = "";
-		for (String key : res.keySet()) {
-			s += "==============" + key + "=============\n";
-			for (String value : res.get(key)) {
+		for (Map.Entry<String, Vector<String>> stringVectorEntry : res.entrySet()) {
+			s += "==============" + stringVectorEntry.getKey() + "=============\n";
+			for (String value : stringVectorEntry.getValue()) {
 				s += value + "\n";
 			}
 		}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/SegmentMapper.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/SegmentMapper.java
@@ -2,6 +2,7 @@ package edu.isi.karma.cleaning;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.internalfunlibrary.InternalTransformationLibrary;
@@ -61,18 +62,18 @@ public class SegmentMapper {
 				groups.put(key, tmp);
 			}			
 		}
-		for(String key: groups.keySet()){
-			if(groups.get(key).size() <= 0 )
+		for(Map.Entry<String, ArrayList<Dataitem>> stringArrayListEntry : groups.entrySet()){
+			if(stringArrayListEntry.getValue().size() <= 0 )
 			{
 				continue;
 			}
 			Vector<int[]> kmappings = new Vector<int[]>();
-			for(Dataitem elem: groups.get(key)){
+			for(Dataitem elem: stringArrayListEntry.getValue()){
 				int[] xtmp = {elem.range[0], elem.range[1], elem.funcid};
 				kmappings.add(xtmp);
 			}
-			int start = groups.get(key).get(0).tarpos;
-			int end = groups.get(key).get(0).tarend;
+			int start = stringArrayListEntry.getValue().get(0).tarpos;
+			int end = stringArrayListEntry.getValue().get(0).tarend;
 			Segment seg = new Segment(start, end+1, kmappings, org, tar);
 			ret.add(seg);			
 		}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Traces.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Traces.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
@@ -364,16 +365,16 @@ public class Traces implements GrammarTreeNode {
 				}
 			}
 		}
-		for (Integer key : allLoops.keySet()) {
-			for (String subkey : allLoops.get(key).keySet()) {
+		for (Map.Entry<Integer, HashMap<String, Vector<Template>>> integerHashMapEntry : allLoops.entrySet()) {
+			for (String subkey : integerHashMapEntry.getValue().keySet()) {
 				Template xline = this
-						.consolidate(allLoops.get(key).get(subkey));
-				if (lLines.containsKey(key)) {
-					lLines.get(key).put(subkey, xline);
+						.consolidate(integerHashMapEntry.getValue().get(subkey));
+				if (lLines.containsKey(integerHashMapEntry.getKey())) {
+					lLines.get(integerHashMapEntry.getKey()).put(subkey, xline);
 				} else {
 					HashMap<String, Template> xHashMap = new HashMap<String, Template>();
 					xHashMap.put(subkey, xline);
-					lLines.put(key, xHashMap);
+					lLines.put(integerHashMapEntry.getKey(), xHashMap);
 				}
 
 			}
@@ -486,15 +487,15 @@ public class Traces implements GrammarTreeNode {
 				tmpStore.put(key, xHashMap);
 			}
 		}
-		for (Integer key : tmpStore.keySet()) {
-			for (String kInteger : tmpStore.get(key).keySet()) {
-				Template x = this.consolidate(tmpStore.get(key).get(kInteger));
-				if (resHashMap.containsKey(key)) {
-					resHashMap.get(key).put(kInteger, x);
+		for (Map.Entry<Integer, HashMap<String, Vector<Template>>> integerHashMapEntry : tmpStore.entrySet()) {
+			for (String kInteger : integerHashMapEntry.getValue().keySet()) {
+				Template x = this.consolidate(integerHashMapEntry.getValue().get(kInteger));
+				if (resHashMap.containsKey(integerHashMapEntry.getKey())) {
+					resHashMap.get(integerHashMapEntry.getKey()).put(kInteger, x);
 				} else {
 					HashMap<String, Template> hashMap = new HashMap<String, Template>();
 					hashMap.put(kInteger, x);
-					resHashMap.put(key, hashMap);
+					resHashMap.put(integerHashMapEntry.getKey(), hashMap);
 				}
 			}
 		}
@@ -517,10 +518,10 @@ public class Traces implements GrammarTreeNode {
 				tmpStore.put(key, xVector);
 			}
 		}
-		for (Integer key : tmpStore.keySet()) {
+		for (Map.Entry<Integer, Vector<Template>> integerVectorEntry : tmpStore.entrySet()) {
 			// System.out.println(""+tmpStore.get(key).toString());
-			Template x = this.consolidate(tmpStore.get(key));
-			resHashMap.put(key, x);
+			Template x = this.consolidate(integerVectorEntry.getValue());
+			resHashMap.put(integerVectorEntry.getKey(), x);
 		}
 		// System.out.println("end consolidating");
 		return resHashMap;
@@ -579,8 +580,8 @@ public class Traces implements GrammarTreeNode {
 				map.put(rep, vIntegers);
 			}
 		}
-		for (String key : map.keySet()) {
-			Vector<Integer> v = map.get(key);
+		for (Map.Entry<String, Vector<Integer>> stringVectorEntry : map.entrySet()) {
+			Vector<Integer> v = stringVectorEntry.getValue();
 			if (v.size() <= 1 || !this.verfiyLoop(v, curPath))
 				continue;
 			Vector<Vector<GrammarTreeNode>> vtn = this.detectLoop(v, curPath);
@@ -880,11 +881,11 @@ public class Traces implements GrammarTreeNode {
 
 	public void tracePrint() {
 		System.out.println("===============printing trace here===============");
-		for (Integer key : this.traceline.keySet()) {
-			System.out.println("" + traceline.get(key));
+		for (Map.Entry<Integer, Template> integerTemplateEntry : this.traceline.entrySet()) {
+			System.out.println("" + integerTemplateEntry.getValue());
 		}
-		for (Integer key : this.loopline.keySet()) {
-			System.out.println("" + loopline.get(key));
+		for (Map.Entry<Integer, HashMap<String, Template>> integerHashMapEntry : this.loopline.entrySet()) {
+			System.out.println("" + integerHashMapEntry.getValue());
 		}
 	}
 	public void emptyState() {

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/UtilTools.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/UtilTools.java
@@ -289,8 +289,8 @@ public class UtilTools {
 		dict.put("\\'", "\\\\'");
 		dict.put("\\|", "\\\\|");
 		dict.put("\\\"", "\\\\\"");
-		for (String key : dict.keySet()) {
-			s = s.replaceAll(key, dict.get(key));
+		for (Entry<String, String> stringStringEntry : dict.entrySet()) {
+			s = s.replaceAll(stringStringEntry.getKey(), stringStringEntry.getValue());
 		}
 		return s;
 	}
@@ -424,9 +424,9 @@ public class UtilTools {
 				res.put(lab, x);
 			}
 		}
-		for (String key : res.keySet()) {
-			ArrayList<String[]> cdata = res.get(key);
-			File f = new File("./log/" + key + ".csv");
+		for (Entry<String, ArrayList<String[]>> stringArrayListEntry : res.entrySet()) {
+			ArrayList<String[]> cdata = stringArrayListEntry.getValue();
+			File f = new File("./log/" + stringArrayListEntry.getKey() + ".csv");
 			CSVWriter cWriter;
 			try {
 				cWriter = new CSVWriter(new FileWriter(f));

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
@@ -5,6 +5,7 @@ import java.io.FileWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import org.slf4j.Logger;
@@ -73,17 +74,17 @@ public class Data2Features {
 					.size() + 1]);
 			attr_names[attr_names.length - 1] = "label";
 			writer.writeNext(attr_names);
-			for (String label : class2Records.keySet()) {
+			for (Map.Entry<String, Vector<String>> stringVectorEntry : class2Records.entrySet()) {
 
-				for (String Record : class2Records.get(label)) {
+				for (String Record : stringVectorEntry.getValue()) {
 					Vector<String> row = new Vector<String>();
-					Collection<Feature> cf = rf.computeFeatures(Record, label);
+					Collection<Feature> cf = rf.computeFeatures(Record, stringVectorEntry.getKey());
 					Feature[] x = cf.toArray(new Feature[cf.size()]);
 					// row.add(f.getName());
 					for (int k = 0; k < cf.size(); k++) {
 						row.add(String.valueOf(x[k].getScore()));
 					}
-					row.add(label); // change this according to the dataset.
+					row.add(stringVectorEntry.getKey()); // change this according to the dataset.
 					String[] dataEntry = row.toArray(new String[row.size()]);
 					writer.writeNext(dataEntry);
 				}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/RecordClassifier.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/RecordClassifier.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import libsvm.svm;
 import libsvm.svm_model;
@@ -156,8 +157,8 @@ public class RecordClassifier implements PartitionClassifierType {
 			}
 		}
 		Double maxNumber = Collections.max(class2weight.values());
-		for (Double key : class2weight.keySet()) {
-			class2weight.put(key, maxNumber / class2weight.get(key) * 1.0);
+		for (Map.Entry<Double, Double> doubleDoubleEntry : class2weight.entrySet()) {
+			class2weight.put(doubleDoubleEntry.getKey(), maxNumber / doubleDoubleEntry.getValue() * 1.0);
 		}
 		return class2weight;
 	}
@@ -332,20 +333,20 @@ public class RecordClassifier implements PartitionClassifierType {
 			ArrayList<svm_node[]> tmpTest = new ArrayList<svm_node[]>();
 			ArrayList<Double> tmpTraintar = new ArrayList<Double>();
 			ArrayList<Double> tmpTesttar = new ArrayList<Double>();
-			for (Double l : labPos.keySet()) {
-				int datasize = labPos.get(l).size();
+			for (Map.Entry<Double, ArrayList<Integer>> doubleArrayListEntry : labPos.entrySet()) {
+				int datasize = doubleArrayListEntry.getValue().size();
 				if (datasize < fold) {
 					// add its own data until reach the fold number
 					int times = fold / datasize;
 					@SuppressWarnings("unchecked")
-					ArrayList<Integer> ditems = (ArrayList<Integer>) labPos.get(l).clone();
+					ArrayList<Integer> ditems = (ArrayList<Integer>) doubleArrayListEntry.getValue().clone();
 					for (int t = 1; t < times+1; t++) {
-						labPos.get(l).addAll(ditems);
+						doubleArrayListEntry.getValue().addAll(ditems);
 					}
-					datasize = labPos.get(l).size();
+					datasize = doubleArrayListEntry.getValue().size();
 				}
 				for (int k = 0; k < datasize; k++) {
-					int itemIndex = labPos.get(l).get(k);
+					int itemIndex = doubleArrayListEntry.getValue().get(k);
 					if (k % fold == i) {
 						tmpTest.add(trainData.get(itemIndex));
 						tmpTesttar.add(targets.get(itemIndex));
@@ -408,9 +409,9 @@ public class RecordClassifier implements PartitionClassifierType {
 		int ptr = 0;
 		int[] wts_labels = new int[parameters.nr_weight];
 		double[] wts = new double[parameters.nr_weight];
-		for (Double key : wtsdict.keySet()) {
-			wts_labels[ptr] = key.intValue();
-			wts[ptr] = wtsdict.get(key);
+		for (Map.Entry<Double, Double> doubleDoubleEntry : wtsdict.entrySet()) {
+			wts_labels[ptr] = doubleDoubleEntry.getKey().intValue();
+			wts[ptr] = doubleDoubleEntry.getValue();
 			ptr++;
 		}
 		parameters.weight_label = wts_labels;

--- a/karma-cleaning/src/main/java/edu/isi/karma/rep/cleaning/RamblerValueCollection.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/rep/cleaning/RamblerValueCollection.java
@@ -22,6 +22,7 @@ package edu.isi.karma.rep.cleaning;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.json.JSONObject;
@@ -92,10 +93,10 @@ public class RamblerValueCollection implements ValueCollection {
 		{
 			JSONObject jb = new JSONObject();
 			Set<String> ss = data.keySet();
-			for(String key:ss)
+			for(Map.Entry<String, String> stringStringEntry : data.entrySet())
 			{
-				String val = data.get(key);
-				jb.put(key, val);
+				String val = stringStringEntry.getValue();
+				jb.put(stringStringEntry.getKey(), val);
 			}
 			return jb;
 		}
@@ -109,9 +110,9 @@ public class RamblerValueCollection implements ValueCollection {
 	{
 		String result = "";
 		Set<String> res = data.keySet();
-		for(String s:res)
+		for(Map.Entry<String, String> stringStringEntry : data.entrySet())
 		{
-			result += data.get(s);
+			result += stringStringEntry.getValue();
 			result += " ";
 		}
 		return result;

--- a/karma-commands/commands-bloom/src/main/java/edu/isi/karma/er/helper/BloomFilterTripleStoreUtil.java
+++ b/karma-commands/commands-bloom/src/main/java/edu/isi/karma/er/helper/BloomFilterTripleStoreUtil.java
@@ -205,15 +205,15 @@ public class BloomFilterTripleStoreUtil extends TripleStoreUtil {
 
 	public boolean updateTripleStoreWithBloomFilters(Map<String, KR2RMLBloomFilter> bfs, Map<String, String> bloomfilterMapping, String modelurl, String context) throws KarmaException, IOException {
 		Set<String> triplemaps = bfs.keySet();
-		for (String tripleUri : triplemaps) {
-			KR2RMLBloomFilter bf = bfs.get(tripleUri);
-			String oldserializedBloomFilter = bloomfilterMapping.get(tripleUri);
+		for (Entry<String, KR2RMLBloomFilter> stringKR2RMLBloomFilterEntry : bfs.entrySet()) {
+			KR2RMLBloomFilter bf = stringKR2RMLBloomFilterEntry.getValue();
+			String oldserializedBloomFilter = bloomfilterMapping.get(stringKR2RMLBloomFilterEntry.getKey());
 			if (oldserializedBloomFilter != null) {
 				KR2RMLBloomFilter bf2 = new KR2RMLBloomFilter();
 				bf2.populateFromCompressedAndBase64EncodedString(oldserializedBloomFilter);
 				bf.or(bf2);
 			}
-			bfs.put(tripleUri, bf);
+			bfs.put(stringKR2RMLBloomFilterEntry.getKey(), bf);
 		}
 		deleteBloomFiltersForMaps(modelurl, null, triplemaps);
 		StringWriter sw = new StringWriter();

--- a/karma-commands/commands-cleaning/src/main/java/edu/isi/karma/controller/command/cleaning/GenerateCleaningRulesCommand.java
+++ b/karma-commands/commands-cleaning/src/main/java/edu/isi/karma/controller/command/cleaning/GenerateCleaningRulesCommand.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import org.json.JSONArray;
@@ -307,12 +308,12 @@ public class GenerateCleaningRulesCommand extends WorksheetSelectionCommand {
 	public String getVarJSON(HashMap<String, HashSet<String>> values) {
 		JSONObject jsobj = new JSONObject();
 		try {
-			for (String key : values.keySet()) {
+			for (Map.Entry<String, HashSet<String>> stringHashSetEntry : values.entrySet()) {
 				JSONArray jsonArray = new JSONArray();
-				HashSet<String> vs = values.get(key);
+				HashSet<String> vs = stringHashSetEntry.getValue();
 				for (String v : vs)
 					jsonArray.put(v);
-				jsobj.put(key, jsonArray);
+				jsobj.put(stringHashSetEntry.getKey(), jsonArray);
 			}
 		} catch (Exception e) {
 			logger.error("value generation error");

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AlignmentSVGVisualizationUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AlignmentSVGVisualizationUpdate.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.jgrapht.graph.DirectedWeightedMultigraph;
@@ -333,9 +334,9 @@ public class AlignmentSVGVisualizationUpdate extends AbstractUpdate {
 			HashMap<Node, Set<ColumnNode>> nodeCoverage = dm.getNodesSpan();
 			/** Identify the max height **/
 			int maxTreeHeight = 0;
-			for (Node node : nodeHeightsMap.keySet()) {
-				if (nodeHeightsMap.get(node) >= maxTreeHeight) {
-					maxTreeHeight = nodeHeightsMap.get(node);
+			for (Map.Entry<Node, Integer> nodeIntegerEntry : nodeHeightsMap.entrySet()) {
+				if (nodeIntegerEntry.getValue() >= maxTreeHeight) {
+					maxTreeHeight = nodeIntegerEntry.getValue();
 				}
 			}
 			/*** Add the nodes and the links from the Steiner tree ***/

--- a/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/FeatureTable.java
+++ b/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/FeatureTable.java
@@ -40,8 +40,8 @@ public class FeatureTable {
 
 	public String getHTMLDescription() {
 		StringBuilder str = new StringBuilder();
-		for (String name : popupData.keySet()) {
-			str.append("<b>" + name + "</b>: " + popupData.get(name)
+		for (Map.Entry<String, String> stringStringEntry : popupData.entrySet()) {
+			str.append("<b>" + stringStringEntry.getKey() + "</b>: " + stringStringEntry.getValue()
 					+ " <br />");
 		}
 		return str.toString();

--- a/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/LineString.java
+++ b/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/LineString.java
@@ -45,8 +45,8 @@ public class LineString {
 
 	public String getHTMLDescription() {
 		StringBuilder str = new StringBuilder();
-		for (String name : popupData.keySet()) {
-			str.append("<b>" + name + "</b>: " + popupData.get(name)
+		for (Map.Entry<String, String> stringStringEntry : popupData.entrySet()) {
+			str.append("<b>" + stringStringEntry.getKey() + "</b>: " + stringStringEntry.getValue()
 					+ " <br />");
 		}
 		return str.toString();

--- a/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/Point.java
+++ b/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/Point.java
@@ -48,8 +48,8 @@ public class Point {
 
 	public String getHTMLDescription() {
 		StringBuilder str = new StringBuilder();
-		for (String name : popupData.keySet()) {
-			str.append("<b>" + name + "</b>: " + popupData.get(name)
+		for (Map.Entry<String, String> stringStringEntry : popupData.entrySet()) {
+			str.append("<b>" + stringStringEntry.getKey() + "</b>: " + stringStringEntry.getValue()
 					+ " <br />");
 		}
 		return str.toString();

--- a/karma-commands/commands-publish/src/main/java/edu/isi/karma/controller/command/publish/PublishReportCommand.java
+++ b/karma-commands/commands-publish/src/main/java/edu/isi/karma/controller/command/publish/PublishReportCommand.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.jgrapht.graph.DirectedWeightedMultigraph;
 import org.json.JSONArray;
@@ -187,8 +188,8 @@ public class PublishReportCommand extends WorksheetCommand {
 		}
 		
 		//Now get all transforms from the map and write them to the writer
-		for(String columnName : pyTransformMap.keySet()) {
-			pw.print(pyTransformMap.get(columnName));
+		for(Map.Entry<String, String> stringStringEntry : pyTransformMap.entrySet()) {
+			pw.print(stringStringEntry.getValue());
 		}
 	}
 	

--- a/karma-commands/commands-publish/src/main/java/edu/isi/karma/model/serialization/DataSourceLoader.java
+++ b/karma-commands/commands-publish/src/main/java/edu/isi/karma/model/serialization/DataSourceLoader.java
@@ -237,10 +237,10 @@ public class DataSourceLoader extends SourceLoader {
 		if (sourceIdsAndMappings == null)
 			return null;
 		
-		for (String sourceId : sourceIdsAndMappings.keySet()) {
-			Model m = Repository.Instance().getNamedModel(sourceId);
+		for (Map.Entry<String, Map<String, String>> stringMapEntry : sourceIdsAndMappings.entrySet()) {
+			Model m = Repository.Instance().getNamedModel(stringMapEntry.getKey());
 			if (m != null)
-				sourcesAndMappings.put(importSourceFromJenaModel(m), sourceIdsAndMappings.get(sourceId));
+				sourcesAndMappings.put(importSourceFromJenaModel(m), stringMapEntry.getValue());
 		}
 		
 		return sourcesAndMappings;
@@ -680,12 +680,12 @@ public class DataSourceLoader extends SourceLoader {
 		}
 		
 		System.out.println("Mappings from matched source to model arguments:");
-		for (Source s : sourcesAndMappings.keySet()) {
-			System.out.println("Source: " + s.getId());
-			if (sourcesAndMappings.get(s) == null)
+		for (Map.Entry<DataSource, Map<String, String>> dataSourceMapEntry : sourcesAndMappings.entrySet()) {
+			System.out.println("Source: " + dataSourceMapEntry.getKey().getId());
+			if (dataSourceMapEntry.getValue() == null)
 				continue;
-			for (String str : sourcesAndMappings.get(s).keySet())
-				System.out.println(str + "-------" + sourcesAndMappings.get(s).get(str));
+			for (String str : dataSourceMapEntry.getValue().keySet())
+				System.out.println(str + "-------" + dataSourceMapEntry.getValue().get(str));
 		}
 
 	}

--- a/karma-commands/commands-publish/src/main/java/edu/isi/karma/model/serialization/DataSourcePublisher.java
+++ b/karma-commands/commands-publish/src/main/java/edu/isi/karma/model/serialization/DataSourcePublisher.java
@@ -166,9 +166,9 @@ public class DataSourcePublisher extends SourcePublisher {
 		// Add source information if any present
 		if(sourceInfo != null) {
 			Map<InfoAttribute, String> attributeValueMap = sourceInfo.getAttributeValueMap();
-			for (InfoAttribute attr : attributeValueMap.keySet()) {
-				Property attrProp = model.createProperty(Namespaces.KARMA, "hasSourceInfo_" + attr.name());
-				my_source.addProperty(attrProp, attributeValueMap.get(attr));
+			for (Map.Entry<InfoAttribute, String> infoAttributeStringEntry : attributeValueMap.entrySet()) {
+				Property attrProp = model.createProperty(Namespaces.KARMA, "hasSourceInfo_" + infoAttributeStringEntry.getKey().name());
+				my_source.addProperty(attrProp, infoAttributeStringEntry.getValue());
 			}
 		}
 		

--- a/karma-commands/commands-update/src/main/java/edu/isi/karma/controller/command/service/PopulateCommand.java
+++ b/karma-commands/commands-update/src/main/java/edu/isi/karma/controller/command/service/PopulateCommand.java
@@ -220,8 +220,8 @@ public class PopulateCommand extends WorksheetSelectionCommand{
 		Map<String, String> attIdToValue = null;
 		for (int i = 0; i < rows.size(); i++) {
 			attIdToValue = new HashMap<String, String>();
-			for (String serviceAttId : serviceToSourceAttMapping.keySet()) {
-				String sourceAttId = serviceToSourceAttMapping.get(serviceAttId);
+			for (Map.Entry<String, String> stringStringEntry : serviceToSourceAttMapping.entrySet()) {
+				String sourceAttId = stringStringEntry.getValue();
 				Attribute sourceAtt = source.getAttribute(sourceAttId);
 				if (sourceAtt == null) {
 //					logger.debug("Cannot find the source attribute with the id " + sourceAttId);
@@ -235,7 +235,7 @@ public class PopulateCommand extends WorksheetSelectionCommand{
 				
 				String value = rows.get(i).getNode(hNodeId).getValue().asString().trim();
 				
-				attIdToValue.put(serviceAttId, value);
+				attIdToValue.put(stringStringEntry.getKey(), value);
 				
 			}
 			String urlString = service.getPopulatedAddress(attIdToValue, null);

--- a/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/GetHeadersCommand.java
+++ b/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/GetHeadersCommand.java
@@ -3,6 +3,7 @@ package edu.isi.karma.controller.command.worksheet;
 import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -76,10 +77,10 @@ public class GetHeadersCommand extends WorksheetCommand {
 				obj.put("HNodeId", hn.getId());
 				HashMap<String, HashSet<HNode>> appliedCommands = hn.getAppliedCommands();
 				JSONArray commands = new JSONArray();
-				for(String command : appliedCommands.keySet()) {
+				for(Map.Entry<String, HashSet<HNode>> stringHashSetEntry : appliedCommands.entrySet()) {
 					JSONObject com = new JSONObject();
-					com.put("CommandName", command);
-					HashSet<HNode> cNodes = appliedCommands.get(command);
+					com.put("CommandName", stringHashSetEntry.getKey());
+					HashSet<HNode> cNodes = stringHashSetEntry.getValue();
 					JSONArray cols = new JSONArray();
 					for(HNode cNode : cNodes) {
 						JSONObject col = new JSONObject();

--- a/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/GroupByCommand.java
+++ b/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/GroupByCommand.java
@@ -189,8 +189,8 @@ public class GroupByCommand extends WorksheetSelectionCommand {
 		newht.addHNode("Values", HNodeType.Transformation, newws, factory);
 		HTable newValueTable = newht.getHNodeFromColumnName("Values").addNestedTable("Table for values", newws, factory);
 		CloneTableUtils.cloneHTable(newValueTable, newws, factory, valuehnodes, false);
-		for (String key : hash.keySet()) {
-			ArrayList<String> r = hash.get(key);
+		for (Entry<String, ArrayList<String>> stringArrayListEntry : hash.entrySet()) {
+			ArrayList<String> r = stringArrayListEntry.getValue();
 			Row lastRow = CloneTableUtils.cloneDataTable(factory.getRow(r.get(0)), newws.getDataTable(), newht, keyhnodes, factory, selection);
 			for (String rowid : r) {
 				Row cur = factory.getRow(rowid);
@@ -244,8 +244,8 @@ public class GroupByCommand extends WorksheetSelectionCommand {
 				hash.put(hashValue, ids);
 			}	
 			
-			for (String key : hash.keySet()) {
-				ArrayList<String> r = hash.get(key);
+			for (Entry<String, ArrayList<String>> stringArrayListEntry : hash.entrySet()) {
+				ArrayList<String> r = stringArrayListEntry.getValue();
 				Node node = parentRow.getNeighbor(newNode.getId());
 				Row lastRow = CloneTableUtils.cloneDataTable(factory.getRow(r.get(0)), node.getNestedTable(), newht, keyhnodes, factory, selection);
 				for (String rowid : r) {

--- a/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/MultipleValueEditColumnCommand.java
+++ b/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/MultipleValueEditColumnCommand.java
@@ -53,16 +53,16 @@ public class MultipleValueEditColumnCommand extends WorksheetCommand {
 	@Override
 	public UpdateContainer doIt(Workspace workspace) throws CommandException {
 		RepFactory factory = workspace.getFactory();
-		for (String rowID: newRowValueMap.keySet()) {
-			Row row = factory.getRow(rowID);
+		for (Map.Entry<String, String> stringStringEntry : newRowValueMap.entrySet()) {
+			Row row = factory.getRow(stringStringEntry.getKey());
 			Node existingNode = row.getNode(hNodeID);
 			if (existingNode.hasNestedTable()) {
 				logger.error("Existing node has a nested table. Cannot overwrite such node with new value. NodeID: " + existingNode.getId());
 				continue;
 			}
 			String existingCellValue = existingNode.getValue().asString();
-			oldRowValueMap.put(rowID, existingCellValue);
-			String newCellValue = newRowValueMap.get(rowID);
+			oldRowValueMap.put(stringStringEntry.getKey(), existingCellValue);
+			String newCellValue = stringStringEntry.getValue();
 			row.setValue(hNodeID, newCellValue, factory);
 		}
 		return WorksheetUpdateFactory.createWorksheetHierarchicalAndCleaningResultsUpdates(this.worksheetId, SuperSelectionManager.DEFAULT_SELECTION, workspace.getContextId());
@@ -71,15 +71,15 @@ public class MultipleValueEditColumnCommand extends WorksheetCommand {
 	@Override
 	public UpdateContainer undoIt(Workspace workspace) {
 		RepFactory factory = workspace.getFactory();
-		for (String rowID: oldRowValueMap.keySet()) {
-			Row row = factory.getRow(rowID);
+		for (Map.Entry<String, String> stringStringEntry : oldRowValueMap.entrySet()) {
+			Row row = factory.getRow(stringStringEntry.getKey());
 			
 			Node existingNode = row.getNode(hNodeID);
 			if (existingNode.hasNestedTable()) {
 				logger.error("Existing node has a nested table. Cannot overwrite such node with new value. NodeID: " + existingNode.getId());
 				continue;
 			}
-			String oldCellValue = oldRowValueMap.get(rowID);
+			String oldCellValue = stringStringEntry.getValue();
 			row.setValue(hNodeID, oldCellValue, factory);
 		}
 		return WorksheetUpdateFactory.createRegenerateWorksheetUpdates(worksheetId, SuperSelectionManager.DEFAULT_SELECTION, workspace.getContextId());

--- a/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/UnfoldCommand.java
+++ b/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/UnfoldCommand.java
@@ -206,17 +206,17 @@ public class UnfoldCommand extends WorksheetSelectionCommand {
 				Node n = row.getNode(key.getId());
 				keyMapping.put(HashValueManager.getHashValue(oldws, n.getId(), factory), n.getValue().asString());
 			}
-			for (String mapkey : keyMapping.keySet()) {
-				HNode hn = newHT.getHNodeFromColumnName(keyMapping.get(mapkey).toLowerCase().replace('/', '_'));
+			for (Entry<String, String> stringStringEntry : keyMapping.entrySet()) {
+				HNode hn = newHT.getHNodeFromColumnName(stringStringEntry.getValue().toLowerCase().replace('/', '_'));
 				if (hn == null) {
-					HNode n = newHT.addHNode(keyMapping.get(mapkey).toLowerCase().replace('/', '_'), HNodeType.Transformation, oldws, factory);
+					HNode n = newHT.addHNode(stringStringEntry.getValue().toLowerCase().replace('/', '_'), HNodeType.Transformation, oldws, factory);
 					outputColumns.add(n.getId());
 					HTable htt = n.addNestedTable("values", oldws, factory);
 					outputColumns.add(htt.addHNode("Values", HNodeType.Transformation, oldws, factory).getId());
-					HNodeidMapping.put(keyMapping.get(mapkey), n.getId());
+					HNodeidMapping.put(stringStringEntry.getValue(), n.getId());
 				}
 				else
-					HNodeidMapping.put(keyMapping.get(mapkey), hn.getId());
+					HNodeidMapping.put(stringStringEntry.getValue(), hn.getId());
 			}
 			Map<String, ArrayList<String>> hash = new HashMap<String, ArrayList<String>>();
 			for (Row row : rows) {
@@ -229,8 +229,8 @@ public class UnfoldCommand extends WorksheetSelectionCommand {
 				//System.out.println("Hash: " + HashValueManager.getHashValue(row, hnodeIDs));
 			}
 
-			for (String hashKey : hash.keySet()) {
-				ArrayList<String> r = hash.get(hashKey);
+			for (Entry<String, ArrayList<String>> stringArrayListEntry : hash.entrySet()) {
+				ArrayList<String> r = stringArrayListEntry.getValue();
 				Node node = parentRow.getNeighbor(newNode.getId());
 				Row lastRow = CloneTableUtils.cloneDataTable(factory.getRow(r.get(0)), node.getNestedTable(), 
 						newHT, hnodes, factory, selection);
@@ -283,11 +283,11 @@ public class UnfoldCommand extends WorksheetSelectionCommand {
 			Node n = row.getNode(key.getId());
 			keyMapping.put(HashValueManager.getHashValue(oldws, n.getId(), factory), n.getValue().asString());
 		}
-		for (String mapkey : keyMapping.keySet()) {
-			HNode n = newws.getHeaders().addHNode(keyMapping.get(mapkey), HNodeType.Transformation, newws, factory);
+		for (Entry<String, String> stringStringEntry : keyMapping.entrySet()) {
+			HNode n = newws.getHeaders().addHNode(stringStringEntry.getValue(), HNodeType.Transformation, newws, factory);
 			HTable ht = n.addNestedTable("values", newws, factory);
 			ht.addHNode("Values", HNodeType.Transformation, newws, factory);
-			HNodeidMapping.put(keyMapping.get(mapkey), n.getId());
+			HNodeidMapping.put(stringStringEntry.getValue(), n.getId());
 		}
 
 		Map<String, ArrayList<String>> hash = new TreeMap<String, ArrayList<String>>();
@@ -300,8 +300,8 @@ public class UnfoldCommand extends WorksheetSelectionCommand {
 			hash.put(hashValue, ids);
 		}
 		List<Row> resultRows = new ArrayList<Row>();
-		for (String hashKey : hash.keySet()) {
-			ArrayList<String> r = hash.get(hashKey);
+		for (Entry<String, ArrayList<String>> stringArrayListEntry : hash.entrySet()) {
+			ArrayList<String> r = stringArrayListEntry.getValue();
 			Row lastRow = CloneTableUtils.cloneDataTable(factory.getRow(r.get(0)), newws.getDataTable(), 
 					newws.getHeaders(), hnodes, factory, selection);
 			for (String rowid : r) {

--- a/karma-common/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
@@ -217,9 +217,9 @@ public class CommandHistory {
 			}
 		}
 
-		for(String worksheetId : comMap.keySet()) {
-			JSONArray comms = comMap.get(worksheetId);
-			historySaver.saveHistory(workspaceId, worksheetId, comms);
+		for(Map.Entry<String, JSONArray> stringJSONArrayEntry : comMap.entrySet()) {
+			JSONArray comms = stringJSONArrayEntry.getValue();
+			historySaver.saveHistory(workspaceId, stringJSONArrayEntry.getKey(), comms);
 		}
 	}
 

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetRDFGenerator.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetRDFGenerator.java
@@ -268,12 +268,12 @@ public class KR2RMLWorksheetRDFGenerator {
 	}
 
 	private void generateColumnProvenanceInformation() {
-		for (String hNodeId:hNodeToContextUriMap.keySet()) {
-			getColumnContextTriples(hNodeId);
+		for (Entry<String, String> stringStringEntry : hNodeToContextUriMap.entrySet()) {
+			getColumnContextTriples(stringStringEntry.getKey());
 
 
 			// Generate wasDerivedFrom property if required
-			HNode hNode = factory.getHNode(hNodeId);
+			HNode hNode = factory.getHNode(stringStringEntry.getKey());
 			if (hNode.isDerivedFromAnotherColumn()) {
 				HNode originalHNode = factory.getHNode(hNode.getOriginalColumnHNodeId());
 				if (originalHNode != null) {
@@ -282,7 +282,7 @@ public class KR2RMLWorksheetRDFGenerator {
 					for(KR2RMLRDFWriter outWriter : outWriters)
 					{
 						outWriter.outputTripleWithURIObject(
-								hNodeToContextUriMap.get(hNodeId), Uris.PROV_WAS_DERIVED_FROM_URI, 
+								stringStringEntry.getValue(), Uris.PROV_WAS_DERIVED_FROM_URI, 
 								getColumnContextUri(originalHNode.getId()));
 					}
 

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/URIFormatter.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/URIFormatter.java
@@ -139,9 +139,9 @@ public class URIFormatter {
 	
 	private void populatePrefixToNamespaceMap(OntologyManager ontMgr) {
 		Map<String, String> prefixMapOntMgr = ontMgr.getPrefixMap(); 
-		for (String ns:prefixMapOntMgr.keySet()) {
-			String prefix = prefixMapOntMgr.get(ns);
-			this.prefixToNamespaceMap.put(prefix, ns);
+		for (Map.Entry<String, String> stringStringEntry : prefixMapOntMgr.entrySet()) {
+			String prefix = stringStringEntry.getValue();
+			this.prefixToNamespaceMap.put(prefix, stringStringEntry.getKey());
 		}
 	}
 	

--- a/karma-common/src/main/java/edu/isi/karma/model/serialization/WebServiceLoader.java
+++ b/karma-common/src/main/java/edu/isi/karma/model/serialization/WebServiceLoader.java
@@ -306,10 +306,10 @@ public class WebServiceLoader extends SourceLoader
 		if (serviceIdsAndMappings == null)
 			return null;
 		
-		for (String serviceId : serviceIdsAndMappings.keySet()) {
-			Model m = Repository.Instance().getNamedModel(serviceId);
+		for (Map.Entry<String, Map<String, String>> stringMapEntry : serviceIdsAndMappings.entrySet()) {
+			Model m = Repository.Instance().getNamedModel(stringMapEntry.getKey());
 			if (m != null)
-				servicesAndMappings.put(importSourceFromJenaModel(m), serviceIdsAndMappings.get(serviceId));
+				servicesAndMappings.put(importSourceFromJenaModel(m), stringMapEntry.getValue());
 		}
 		
 		return servicesAndMappings;
@@ -340,10 +340,10 @@ public class WebServiceLoader extends SourceLoader
 		if (serviceIdsAndMappings == null)
 			return null;
 		
-		for (String serviceId : serviceIdsAndMappings.keySet()) {
-			Model m = Repository.Instance().getNamedModel(serviceId);
+		for (Map.Entry<String, Map<String, String>> stringMapEntry : serviceIdsAndMappings.entrySet()) {
+			Model m = Repository.Instance().getNamedModel(stringMapEntry.getKey());
 			if (m != null)
-				servicesAndMappings.put(importSourceFromJenaModel(m), serviceIdsAndMappings.get(serviceId));
+				servicesAndMappings.put(importSourceFromJenaModel(m), stringMapEntry.getValue());
 		}
 		
 		return servicesAndMappings;
@@ -925,12 +925,12 @@ public class WebServiceLoader extends SourceLoader
 		}
 		
 		System.out.println("Mappings from matched source to model arguments:");
-		for (WebService s : servicesAndMappings.keySet()) {
-			System.out.println("Service: " + s.getId());
-			if (servicesAndMappings.get(s) == null)
+		for (Map.Entry<WebService, Map<String, String>> webServiceMapEntry : servicesAndMappings.entrySet()) {
+			System.out.println("Service: " + webServiceMapEntry.getKey().getId());
+			if (webServiceMapEntry.getValue() == null)
 				continue;
-			for (String str : servicesAndMappings.get(s).keySet())
-				System.out.println(str + "-------" + servicesAndMappings.get(s).get(str));
+			for (String str : webServiceMapEntry.getValue().keySet())
+				System.out.println(str + "-------" + webServiceMapEntry.getValue().get(str));
 		}
 
 	}

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/AlignmentManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/AlignmentManager.java
@@ -21,6 +21,7 @@
 package edu.isi.karma.modeling.alignment;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import edu.isi.karma.modeling.ontology.OntologyManager;
@@ -49,9 +50,9 @@ public class AlignmentManager {
 	}
 	
 	public String getAlignmentId(Alignment alignment) {
-		for(String id: alignmentMap.keySet()) {
-			if(alignmentMap.get(id) == alignment)
-				return id;
+		for(Map.Entry<String, Alignment> stringAlignmentEntry : alignmentMap.entrySet()) {
+			if(stringAlignmentEntry.getValue() == alignment)
+				return stringAlignmentEntry.getKey();
 		}
 		return null;
 	}

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphBuilder.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphBuilder.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.jgrapht.graph.DirectedWeightedMultigraph;
@@ -1035,9 +1036,9 @@ public class GraphBuilder {
 		int count = 1;
 		while (count != 0) {
 			count = 0;
-			for (String s : dependentUrisMap.keySet()) {
-				Set<String> temp = this.uriClosure.get(s);
-				Set<String> dependentUris = dependentUrisMap.get(s);
+			for (Map.Entry<String, Set<String>> stringSetEntry : dependentUrisMap.entrySet()) {
+				Set<String> temp = this.uriClosure.get(stringSetEntry.getKey());
+				Set<String> dependentUris = stringSetEntry.getValue();
 				for (String ss : dependentUris) {
 					if (!temp.contains(ss)) { temp.add(ss); count++;}
 					if (this.uriClosure.get(ss) != null) {

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/learner/ModelLearningGraphCompact.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/learner/ModelLearningGraphCompact.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -82,14 +83,14 @@ public class ModelLearningGraphCompact extends ModelLearningGraph {
 			}
 		}
 		
-		for (String uri : uriCount.keySet()) {
-			int modelNodeCount = uriCount.get(uri);
-			Set<Node> matchedNodes = this.graphBuilder.getUriToNodesMap().get(uri);
+		for (Map.Entry<String, Integer> stringIntegerEntry : uriCount.entrySet()) {
+			int modelNodeCount = stringIntegerEntry.getValue();
+			Set<Node> matchedNodes = this.graphBuilder.getUriToNodesMap().get(stringIntegerEntry.getKey());
 			int graphNodeCount = matchedNodes == null ? 0 : matchedNodes.size();
 			
 			for (int i = 0; i < modelNodeCount - graphNodeCount; i++) {
-				String id = this.nodeIdFactory.getNodeId(uri);
-				Node n = new InternalNode(id, new Label(uri));
+				String id = this.nodeIdFactory.getNodeId(stringIntegerEntry.getKey());
+				Node n = new InternalNode(id, new Label(stringIntegerEntry.getKey()));
 				if (this.graphBuilder.addNode(n))
 					addedNodes.add((InternalNode)n);
 			}

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/learner/ModelLearningGraphCompact_Old.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/learner/ModelLearningGraphCompact_Old.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -89,14 +90,14 @@ public class ModelLearningGraphCompact_Old extends ModelLearningGraph {
 			}
 		}
 		
-		for (String uri : uriCount.keySet()) {
-			int modelNodeCount = uriCount.get(uri);
-			Set<Node> matchedNodes = this.graphBuilder.getUriToNodesMap().get(uri);
+		for (Map.Entry<String, Integer> stringIntegerEntry : uriCount.entrySet()) {
+			int modelNodeCount = stringIntegerEntry.getValue();
+			Set<Node> matchedNodes = this.graphBuilder.getUriToNodesMap().get(stringIntegerEntry.getKey());
 			int graphNodeCount = matchedNodes == null ? 0 : matchedNodes.size();
 			
 			for (int i = 0; i < modelNodeCount - graphNodeCount; i++) {
-				String id = this.nodeIdFactory.getNodeId(uri);
-				Node n = new InternalNode(id, new Label(uri));
+				String id = this.nodeIdFactory.getNodeId(stringIntegerEntry.getKey());
+				Node n = new InternalNode(id, new Label(stringIntegerEntry.getKey()));
 				if (this.graphBuilder.addNode(n))
 					addedNodes.add((InternalNode)n);
 			}

--- a/karma-common/src/main/java/edu/isi/karma/modeling/ontology/OntologyCache.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/ontology/OntologyCache.java
@@ -22,6 +22,7 @@ package edu.isi.karma.modeling.ontology;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -844,14 +845,14 @@ public class OntologyCache {
 			this.indirectSuperClasses.put(c, indirectSuperClassesLocal);
 		}		
 		
-		for (String c : this.indirectSuperClasses.keySet()) {
+		for (Entry<String, HashMap<String, Label>> stringHashMapEntry : this.indirectSuperClasses.entrySet()) {
 			
-			HashMap<String, Label> superClasses = this.indirectSuperClasses.get(c);
+			HashMap<String, Label> superClasses = this.indirectSuperClasses.get(stringHashMapEntry.getKey());
 			if (superClasses == null) {
 				superClasses = new HashMap<String, Label>();
-				this.indirectSuperClasses.put(c, superClasses); 
+				this.indirectSuperClasses.put(stringHashMapEntry.getKey(), superClasses); 
 			}
-			if (!c.equalsIgnoreCase(Uris.THING_URI) && !superClasses.containsKey(Uris.THING_URI))
+			if (!stringHashMapEntry.getKey().equalsIgnoreCase(Uris.THING_URI) && !superClasses.containsKey(Uris.THING_URI))
 				superClasses.put(Uris.THING_URI, new Label(Uris.THING_URI, Namespaces.OWL, Prefixes.OWL));
 		}
 		
@@ -1518,12 +1519,12 @@ public class OntologyCache {
 		HashSet<String> directRanges;
 		HashSet<String> indirectRanges;
 		
-		for (String p : this.dataProperties.keySet()) {
+		for (Entry<String, Label> stringLabelEntry : this.dataProperties.entrySet()) {
 			
-			label = this.dataProperties.get(p);
+			label = this.dataProperties.get(stringLabelEntry.getKey());
 			
-			directDomains = propertyDirectDomains.get(p);
-			indirectDomains = propertyIndirectDomains.get(p);
+			directDomains = propertyDirectDomains.get(stringLabelEntry.getKey());
+			indirectDomains = propertyIndirectDomains.get(stringLabelEntry.getKey());
 
 			haveDomain = true;
 			
@@ -1536,18 +1537,18 @@ public class OntologyCache {
 				haveDomain = false;
 			
 			if (!haveDomain)
-				this.dataPropertiesWithoutDomain.put(p, label);
+				this.dataPropertiesWithoutDomain.put(stringLabelEntry.getKey(), label);
 		}
 		
-		for (String p : this.objectProperties.keySet()) {
+		for (Entry<String, Label> stringLabelEntry : this.objectProperties.entrySet()) {
 			
-			label = this.objectProperties.get(p);
+			label = this.objectProperties.get(stringLabelEntry.getKey());
 			
-			directDomains = propertyDirectDomains.get(p);
-			directRanges = propertyDirectRanges.get(p);
+			directDomains = propertyDirectDomains.get(stringLabelEntry.getKey());
+			directRanges = propertyDirectRanges.get(stringLabelEntry.getKey());
 
-			indirectDomains = propertyIndirectDomains.get(p);
-			indirectRanges = propertyIndirectRanges.get(p);
+			indirectDomains = propertyIndirectDomains.get(stringLabelEntry.getKey());
+			indirectRanges = propertyIndirectRanges.get(stringLabelEntry.getKey());
 
 			haveDomain = true;
 			haveRange = true;
@@ -1561,13 +1562,13 @@ public class OntologyCache {
 				haveRange = false;
 			
 			if (haveDomain && !haveRange) 
-				this.objectPropertiesWithOnlyDomain.put(p, label);
+				this.objectPropertiesWithOnlyDomain.put(stringLabelEntry.getKey(), label);
 			else if (!haveDomain && haveRange) {
-				this.objectPropertiesWithOnlyRange.put(p, label);
+				this.objectPropertiesWithOnlyRange.put(stringLabelEntry.getKey(), label);
 			}
 			else if (!haveDomain && !haveRange) {
-				if (!p.startsWith(Namespaces.RDF) && !p.startsWith(Namespaces.RDFS))
-					this.objectPropertiesWithoutDomainAndRange.put(p, label);
+				if (!stringLabelEntry.getKey().startsWith(Namespaces.RDF) && !stringLabelEntry.getKey().startsWith(Namespaces.RDFS))
+					this.objectPropertiesWithoutDomainAndRange.put(stringLabelEntry.getKey(), label);
 			}
 		}
 }

--- a/karma-common/src/main/java/edu/isi/karma/modeling/ontology/OntologyManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/ontology/OntologyManager.java
@@ -556,9 +556,9 @@ public class OntologyManager  {
 		Map<String, String> nsMap = ontHandler.getOntModel().getNsPrefixMap();
 		Map<String, String> prefixMap = new HashMap<String, String>();
 		
-		for(String ns: nsMap.keySet()) {
-			if (!ns.equals("") && !prefixMap.containsKey(nsMap.get(ns)))
-				prefixMap.put(nsMap.get(ns), ns);
+		for(Map.Entry<String, String> stringStringEntry : nsMap.entrySet()) {
+			if (!stringStringEntry.getKey().equals("") && !prefixMap.containsKey(stringStringEntry.getValue()))
+				prefixMap.put(stringStringEntry.getValue(), stringStringEntry.getKey());
 		}
 		return prefixMap;
 	}

--- a/karma-common/src/main/java/edu/isi/karma/modeling/semantictypes/SemanticTypeColumnModel.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/semantictypes/SemanticTypeColumnModel.java
@@ -23,6 +23,7 @@ package edu.isi.karma.modeling.semantictypes;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.json.JSONArray;
@@ -61,10 +62,10 @@ public class SemanticTypeColumnModel implements Jsonizable {
 	public void write(JSONWriter writer) throws JSONException {
 		writer.object();
 		writer.array();
-		for (String label : scoreMap.keySet()) {
+		for (Map.Entry<String, Double> stringDoubleEntry : scoreMap.entrySet()) {
 			writer.object();
-			writer.key(SemanticTypesUpdate.JsonKeys.FullType.name()).value(label);
-			writer.key("probability").value(scoreMap.get(label));
+			writer.key(SemanticTypesUpdate.JsonKeys.FullType.name()).value(stringDoubleEntry.getKey());
+			writer.key("probability").value(stringDoubleEntry.getValue());
 			writer.endObject();
 		}
 		writer.endArray();

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/TopKSteinertrees.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/TopKSteinertrees.java
@@ -56,11 +56,11 @@ public abstract class TopKSteinertrees {
 		for(SteinerNode n: graph.keySet()){
 			fw.write(nodeToId.get(n.name())+" "+"0.0 "+nodeToId.get(n.name())+" \n");
 		}
-		for(SteinerNode n: graph.keySet()){
-			for(SteinerEdge e: graph.get(n)){
-				if(nodeToId.get(n.name())==null) nodeToId.put(n.name(),1);
-				fw.write(nodeToId.get(n.name())+" "
-						+nodeToId.get(n.getNeighborInEdge(e).name())+" "+e.weight()+"\n");
+		for(Map.Entry<SteinerNode, TreeSet<SteinerEdge>> steinerNodeTreeSetEntry : graph.entrySet()){
+			for(SteinerEdge e: steinerNodeTreeSetEntry.getValue()){
+				if(nodeToId.get(steinerNodeTreeSetEntry.getKey().name())==null) nodeToId.put(steinerNodeTreeSetEntry.getKey().name(),1);
+				fw.write(nodeToId.get(steinerNodeTreeSetEntry.getKey().name())+" "
+						+nodeToId.get(steinerNodeTreeSetEntry.getKey().getNeighborInEdge(e).name())+" "+e.weight()+"\n");
 			}
 		}
 		fw.close();
@@ -90,10 +90,10 @@ public abstract class TopKSteinertrees {
 		
 		FileWriter fw= new FileWriter(folder+fileName+"STAR.txt");
 		TreeSet<SteinerEdge> ts = new TreeSet<SteinerEdge>();
-		for(SteinerNode n: graph.keySet()){
-			for(SteinerEdge e: graph.get(n)){
+		for(Map.Entry<SteinerNode, TreeSet<SteinerEdge>> steinerNodeTreeSetEntry : graph.entrySet()){
+			for(SteinerEdge e: steinerNodeTreeSetEntry.getValue()){
 				if(ts.contains(e))continue;
-				fw.write(e.getEdgeLabel()+" : "+e.weight()+" : "+n.name()+" : "+n.getNeighborInEdge(e).name()+" : "+e.sourceNode.equals(n)+"\n");
+				fw.write(e.getEdgeLabel()+" : "+e.weight()+" : "+ steinerNodeTreeSetEntry.getKey().name()+" : "+ steinerNodeTreeSetEntry.getKey().getNeighborInEdge(e).name()+" : "+e.sourceNode.equals(steinerNodeTreeSetEntry.getKey())+"\n");
 				ts.add(e);
 			}
 		}

--- a/karma-common/src/main/java/edu/isi/karma/rep/alignment/DisplayModel.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/alignment/DisplayModel.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
@@ -89,13 +90,13 @@ public class DisplayModel {
 		List<Node> noSpanNodes = new ArrayList<>();
 		int maxLevel = getMaxLevel(true);
 		
-		for(Node n : nodesSpan.keySet()) {
-			if(nodesSpan.get(n).size() == 0) {
-				noSpanNodes.add(n);
+		for(Entry<Node, Set<ColumnNode>> nodeSetEntry : nodesSpan.entrySet()) {
+			if(nodeSetEntry.getValue().size() == 0) {
+				noSpanNodes.add(nodeSetEntry.getKey());
 			} else {
-				spanNodes.add(n);
+				spanNodes.add(nodeSetEntry.getKey());
 			}
-			nodesLevel.put(n, maxLevel - nodesLevel.get(n));
+			nodesLevel.put(nodeSetEntry.getKey(), maxLevel - nodesLevel.get(nodeSetEntry.getKey()));
 		}
 		
 		maxLevel = getMaxLevel(spanNodes);

--- a/karma-common/src/main/java/edu/isi/karma/rep/model/Model.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/model/Model.java
@@ -331,10 +331,10 @@ public class Model {
 	private static String getSparqlHeader(Map<String, String> nsToPrefixMapping) {
 		String prefixHeader = "";
 		
-		for (String ns : nsToPrefixMapping.keySet()) {
-			String prefix = nsToPrefixMapping.get(ns);
+		for (Map.Entry<String, String> stringStringEntry : nsToPrefixMapping.entrySet()) {
+			String prefix = stringStringEntry.getValue();
 			if (prefix != null)
-				prefixHeader += "PREFIX " + prefix + ": <" + ns + "> \n";
+				prefixHeader += "PREFIX " + prefix + ": <" + stringStringEntry.getKey() + "> \n";
 		}
 
 		return prefixHeader;

--- a/karma-common/src/main/java/edu/isi/karma/util/HTTPUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/HTTPUtil.java
@@ -67,8 +67,8 @@ public class HTTPUtil {
 		
 		// Prepare the message body parameters
 		List<NameValuePair> formParams = new ArrayList<NameValuePair>();
-		for (String param:formParameters.keySet()) {
-			formParams.add(new BasicNameValuePair(param, formParameters.get(param)));
+		for (Map.Entry<String, String> stringStringEntry : formParameters.entrySet()) {
+			formParams.add(new BasicNameValuePair(stringStringEntry.getKey(), stringStringEntry.getValue()));
 		}
 		
 		return executeHTTPPostRequest(serviceURL, contentType, acceptContentType, new UrlEncodedFormEntity(formParams, "UTF-8"));

--- a/karma-common/src/main/java/edu/isi/karma/util/Util.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/Util.java
@@ -41,8 +41,8 @@ public class Util {
 	public static HashMap<String, Double> sortHashMap(
 			HashMap<String, Double> input) {
 		Map<String, Double> tempMap = new HashMap<String, Double>();
-		for (String wsState : input.keySet()) {
-			tempMap.put(wsState, input.get(wsState));
+		for (Map.Entry<String, Double> stringDoubleEntry : input.entrySet()) {
+			tempMap.put(stringDoubleEntry.getKey(), stringDoubleEntry.getValue());
 		}
 
 		List<String> mapKeys = new ArrayList<String>(tempMap.keySet());

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/Context.java
@@ -715,11 +715,10 @@ public class Context extends LinkedHashMap<String, Object> {
         // 4)
         String compactIRI = null;
         // 5)
-        for (final String term : termDefinitions.keySet()) {
-            final Map<String, Object> termDefinition = (Map<String, Object>) termDefinitions
-                    .get(term);
+        for (final Map.Entry<String, Object> stringObjectEntry : termDefinitions.entrySet()) {
+            final Map<String, Object> termDefinition = (Map<String, Object>) stringObjectEntry.getValue();
             // 5.1)
-            if (term.contains(":")) {
+            if (stringObjectEntry.getKey().contains(":")) {
                 continue;
             }
             // 5.2)
@@ -729,7 +728,7 @@ public class Context extends LinkedHashMap<String, Object> {
             }
 
             // 5.3)
-            final String candidate = term + ":"
+            final String candidate = stringObjectEntry.getKey() + ":"
                     + iri.substring(((String) termDefinition.get("@id")).length());
             // 5.4)
             if ((compactIRI == null || compareShortestLeast(candidate, compactIRI) < 0)
@@ -773,12 +772,11 @@ public class Context extends LinkedHashMap<String, Object> {
      */
     public Map<String, String> getPrefixes(boolean onlyCommonPrefixes) {
         final Map<String, String> prefixes = new LinkedHashMap<String, String>();
-        for (final String term : termDefinitions.keySet()) {
-            if (term.contains(":")) {
+        for (final Map.Entry<String, Object> stringObjectEntry : termDefinitions.entrySet()) {
+            if (stringObjectEntry.getKey().contains(":")) {
                 continue;
             }
-            final Map<String, Object> termDefinition = (Map<String, Object>) termDefinitions
-                    .get(term);
+            final Map<String, Object> termDefinition = (Map<String, Object>) stringObjectEntry.getValue();
             if (termDefinition == null) {
                 continue;
             }
@@ -786,11 +784,11 @@ public class Context extends LinkedHashMap<String, Object> {
             if (id == null) {
                 continue;
             }
-            if (term.startsWith("@") || id.startsWith("@")) {
+            if (stringObjectEntry.getKey().startsWith("@") || id.startsWith("@")) {
                 continue;
             }
             if (!onlyCommonPrefixes || id.endsWith("/") || id.endsWith("#")) {
-                prefixes.put(term, id);
+                prefixes.put(stringObjectEntry.getKey(), id);
             }
         }
         return prefixes;
@@ -1081,20 +1079,20 @@ public class Context extends LinkedHashMap<String, Object> {
         if (this.get("@vocab") != null) {
             ctx.put("@vocab", this.get("@vocab"));
         }
-        for (final String term : termDefinitions.keySet()) {
-            final Map<String, Object> definition = (Map<String, Object>) termDefinitions.get(term);
+        for (final Map.Entry<String, Object> stringObjectEntry : termDefinitions.entrySet()) {
+            final Map<String, Object> definition = (Map<String, Object>) stringObjectEntry.getValue();
             if (definition.get("@language") == null
                     && definition.get("@container") == null
                     && definition.get("@type") == null
                     && (definition.get("@reverse") == null || Boolean.FALSE.equals(definition
                             .get("@reverse")))) {
                 final String cid = this.compactIri((String) definition.get("@id"));
-                ctx.put(term, term.equals(cid) ? definition.get("@id") : cid);
+                ctx.put(stringObjectEntry.getKey(), stringObjectEntry.getKey().equals(cid) ? definition.get("@id") : cid);
             } else {
                 final Map<String, Object> defn = newMap();
                 final String cid = this.compactIri((String) definition.get("@id"));
                 final Boolean reverseProperty = Boolean.TRUE.equals(definition.get("@reverse"));
-                if (!(term.equals(cid) && !reverseProperty)) {
+                if (!(stringObjectEntry.getKey().equals(cid) && !reverseProperty)) {
                     defn.put(reverseProperty ? "@reverse" : "@id", cid);
                 }
                 final String typeMapping = (String) definition.get("@type");
@@ -1109,7 +1107,7 @@ public class Context extends LinkedHashMap<String, Object> {
                 if (definition.get("@language") != null) {
                     defn.put("@language", Boolean.FALSE.equals(lang) ? null : lang);
                 }
-                ctx.put(term, defn);
+                ctx.put(stringObjectEntry.getKey(), defn);
             }
         }
 

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -665,18 +665,18 @@ public class JsonLdApi {
                         if (((Map<String, Object>) expandedValue).containsKey("@reverse")) {
                             final Map<String, Object> reverse = (Map<String, Object>) ((Map<String, Object>) expandedValue)
                                     .get("@reverse");
-                            for (final String property : reverse.keySet()) {
-                                final Object item = reverse.get(property);
+                            for (final Map.Entry<String, Object> stringObjectEntry : reverse.entrySet()) {
+                                final Object item = stringObjectEntry.getValue();
                                 // 7.4.11.2.1)
-                                if (!result.containsKey(property)) {
-                                    result.put(property, new ArrayList<Object>());
+                                if (!result.containsKey(stringObjectEntry.getKey())) {
+                                    result.put(stringObjectEntry.getKey(), new ArrayList<Object>());
                                 }
                                 // 7.4.11.2.2)
                                 if (item instanceof List) {
-                                    ((List<Object>) result.get(property))
+                                    ((List<Object>) result.get(stringObjectEntry.getKey()))
                                     .addAll((List<Object>) item);
                                 } else {
-                                    ((List<Object>) result.get(property)).add(item);
+                                    ((List<Object>) result.get(stringObjectEntry.getKey())).add(item);
                                 }
                             }
                         }
@@ -1139,12 +1139,12 @@ public class JsonLdApi {
                 final Map<String, Object> reverseMap = (Map<String, Object>) elem
                         .remove("@reverse");
                 // 6.9.3)
-                for (final String property : reverseMap.keySet()) {
-                    final List<Object> values = (List<Object>) reverseMap.get(property);
+                for (final Map.Entry<String, Object> stringObjectEntry : reverseMap.entrySet()) {
+                    final List<Object> values = (List<Object>) stringObjectEntry.getValue();
                     // 6.9.3.1)
                     for (final Object value : values) {
                         // 6.9.3.1.1)
-                        generateNodeMap(value, nodeMap, activeGraph, referencedNode, property, null);
+                        generateNodeMap(value, nodeMap, activeGraph, referencedNode, stringObjectEntry.getKey(), null);
                     }
                 }
             }
@@ -1554,16 +1554,16 @@ public class JsonLdApi {
 
     private static void removeDependents(Map<String, EmbedNode> embeds, String id) {
         // get embed keys as a separate array to enable deleting keys in map
-        for (final String id_dep : embeds.keySet()) {
-            final EmbedNode e = embeds.get(id_dep);
+        for (final Map.Entry<String, EmbedNode> stringEmbedNodeEntry : embeds.entrySet()) {
+            final EmbedNode e = stringEmbedNodeEntry.getValue();
             final Object p = e.parent != null ? e.parent : newMap();
             if (!(p instanceof Map)) {
                 continue;
             }
             final String pid = (String) ((Map<String, Object>) p).get("@id");
             if (Obj.equals(id, pid)) {
-                embeds.remove(id_dep);
-                removeDependents(embeds, id_dep);
+                embeds.remove(stringEmbedNodeEntry.getKey());
+                removeDependents(embeds, stringEmbedNodeEntry.getKey());
             }
         }
     }
@@ -1571,10 +1571,10 @@ public class JsonLdApi {
     private Map<String, Object> filterNodes(FramingContext state, Map<String, Object> nodes,
             Map<String, Object> frame) throws JsonLdError {
         final Map<String, Object> rval = newMap();
-        for (final String id : nodes.keySet()) {
-            final Map<String, Object> element = (Map<String, Object>) nodes.get(id);
+        for (final Map.Entry<String, Object> stringObjectEntry : nodes.entrySet()) {
+            final Map<String, Object> element = (Map<String, Object>) stringObjectEntry.getValue();
             if (element != null && filterNode(state, element, frame)) {
-                rval.put(id, element);
+                rval.put(stringObjectEntry.getKey(), element);
             }
         }
         return rval;
@@ -1678,13 +1678,13 @@ public class JsonLdApi {
                     if (s == null) {
                         s = newMap("@id", sid);
                     }
-                    for (final String prop : s.keySet()) {
+                    for (final Map.Entry<String, Object> stringObjectEntry : s.entrySet()) {
                         // copy keywords
-                        if (isKeyword(prop)) {
-                            ((Map<String, Object>) o).put(prop, JsonLdUtils.clone(s.get(prop)));
+                        if (isKeyword(stringObjectEntry.getKey())) {
+                            ((Map<String, Object>) o).put(stringObjectEntry.getKey(), JsonLdUtils.clone(stringObjectEntry.getValue()));
                             continue;
                         }
-                        embedValues(state, s, prop, o);
+                        embedValues(state, s, stringObjectEntry.getKey(), o);
                     }
                 }
                 addFrameOutput(state, output, property, o);
@@ -1852,8 +1852,8 @@ public class JsonLdApi {
         }
 
         // 4)
-        for (final String name : graphMap.keySet()) {
-            final Map<String, NodeMapNode> graph = graphMap.get(name);
+        for (final Map.Entry<String, Map<String, NodeMapNode>> stringMapEntry : graphMap.entrySet()) {
+            final Map<String, NodeMapNode> graph = stringMapEntry.getValue();
 
             // 4.1)
             if (!graph.containsKey(RDF_NIL)) {
@@ -1975,14 +1975,14 @@ public class JsonLdApi {
 
         final RDFDataset dataset = new RDFDataset(this);
 
-        for (final String graphName : nodeMap.keySet()) {
+        for (final Map.Entry<String, Object> stringObjectEntry : nodeMap.entrySet()) {
             // 4.1)
-            if (JsonLdUtils.isRelativeIri(graphName)) {
+            if (JsonLdUtils.isRelativeIri(stringObjectEntry.getKey())) {
                 continue;
             }
-            final Map<String, Object> graph = (Map<String, Object>) nodeMap.get(graphName);
+            final Map<String, Object> graph = (Map<String, Object>) stringObjectEntry.getValue();
             replaceBlankNode(graph);
-            dataset.graphToRDF(graphName, graph);
+            dataset.graphToRDF(stringObjectEntry.getKey(), graph);
         }
 
         return dataset;

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
@@ -197,16 +197,16 @@ public class JsonLdProcessor {
         // 3)
         final Map<String, Object> defaultGraph = (Map<String, Object>) nodeMap.remove("@default");
         // 4)
-        for (final String graphName : nodeMap.keySet()) {
-            final Map<String, Object> graph = (Map<String, Object>) nodeMap.get(graphName);
+        for (final Map.Entry<String, Object> stringObjectEntry : nodeMap.entrySet()) {
+            final Map<String, Object> graph = (Map<String, Object>) stringObjectEntry.getValue();
             // 4.1+4.2)
             Map<String, Object> entry;
-            if (!defaultGraph.containsKey(graphName)) {
+            if (!defaultGraph.containsKey(stringObjectEntry.getKey())) {
                 entry = newMap();
-                entry.put("@id", graphName);
-                defaultGraph.put(graphName, entry);
+                entry.put("@id", stringObjectEntry.getKey());
+                defaultGraph.put(stringObjectEntry.getKey(), entry);
             } else {
-                entry = (Map<String, Object>) defaultGraph.get(graphName);
+                entry = (Map<String, Object>) defaultGraph.get(stringObjectEntry.getKey());
             }
             // 4.3)
             // TODO: SPEC doesn't specify that this should only be added if it

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
@@ -48,9 +48,9 @@ public class JsonLdUtils {
             if (m1.size() != m2.size()) {
                 return false;
             }
-            for (final String key : m1.keySet()) {
-                if (!m2.containsKey(key)
-                        || !deepCompare(m1.get(key), m2.get(key), listOrderMatters)) {
+            for (final Map.Entry<String, Object> stringObjectEntry : m1.entrySet()) {
+                if (!m2.containsKey(stringObjectEntry.getKey())
+                        || !deepCompare(stringObjectEntry.getValue(), m2.get(stringObjectEntry.getKey()), listOrderMatters)) {
                     return false;
                 }
             }

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDataset.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDataset.java
@@ -423,15 +423,15 @@ public class RDFDataset extends LinkedHashMap<String, Object> {
         // And then leak to us the potential 'prefixes'
         final Map<String, String> prefixes = context.getPrefixes(true);
 
-        for (final String key : prefixes.keySet()) {
-            final String val = prefixes.get(key);
-            if ("@vocab".equals(key)) {
+        for (final Map.Entry<String, String> stringStringEntry : prefixes.entrySet()) {
+            final String val = stringStringEntry.getValue();
+            if ("@vocab".equals(stringStringEntry.getKey())) {
                 if (val == null || isString(val)) {
                     setNamespace("", val);
                 } else {
                 }
-            } else if (!isKeyword(key)) {
-                setNamespace(key, val);
+            } else if (!isKeyword(stringStringEntry.getKey())) {
+                setNamespace(stringStringEntry.getKey(), val);
                 // TODO: should we make sure val is a valid URI prefix (i.e. it
                 // ends with /# or ?)
                 // or is it ok that full URIs for terms are used?

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDatasetUtils.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDatasetUtils.java
@@ -27,8 +27,8 @@ public class RDFDatasetUtils {
     @Deprecated
     static List<Object> graphToRDF(Map<String, Object> graph, UniqueNamer namer) {
         final List<Object> rval = new ArrayList<Object>();
-        for (final String id : graph.keySet()) {
-            final Map<String, Object> node = (Map<String, Object>) graph.get(id);
+        for (final Map.Entry<String, Object> stringObjectEntry : graph.entrySet()) {
+            final Map<String, Object> node = (Map<String, Object>) stringObjectEntry.getValue();
             final List<String> properties = new ArrayList<String>(node.keySet());
             Collections.sort(properties);
             for (String property : properties) {
@@ -42,12 +42,12 @@ public class RDFDatasetUtils {
                 for (final Object item : (List<Object>) items) {
                     // RDF subjects
                     final Map<String, Object> subject = newMap();
-                    if (id.indexOf("_:") == 0) {
+                    if (stringObjectEntry.getKey().indexOf("_:") == 0) {
                         subject.put("type", "blank node");
-                        subject.put("value", namer.getName(id));
+                        subject.put("value", namer.getName(stringObjectEntry.getKey()));
                     } else {
                         subject.put("type", "IRI");
-                        subject.put("value", id);
+                        subject.put("value", stringObjectEntry.getKey());
                     }
 
                     // RDF predicates

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/impl/TurtleTripleCallback.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/impl/TurtleTripleCallback.java
@@ -163,33 +163,33 @@ public class TurtleTripleCallback implements JsonLdTripleCallback {
 
         // process refs (nesting referenced bnodes if only one reference to them
         // in the whole graph)
-        for (final String id : refs.keySet()) {
+        for (final Entry<String, List<Object>> stringListEntry : refs.entrySet()) {
             // skip items if there is more than one reference to them in the
             // graph
-            if (refs.get(id).size() > 1) {
+            if (stringListEntry.getValue().size() > 1) {
                 continue;
             }
 
             // otherwise embed them into the referenced location
-            Object object = ttl.remove(id);
-            if (collections.containsKey(id)) {
+            Object object = ttl.remove(stringListEntry.getKey());
+            if (collections.containsKey(stringListEntry.getKey())) {
                 object = new LinkedHashMap<String, List<Object>>();
                 final List<Object> tmp = new ArrayList<Object>();
-                tmp.add(collections.remove(id));
+                tmp.add(collections.remove(stringListEntry.getKey()));
                 ((HashMap<String, Object>) object).put(COLS_KEY, tmp);
             }
-            final List<Object> predicate = (List<Object>) refs.get(id).get(0);
+            final List<Object> predicate = (List<Object>) stringListEntry.getValue().get(0);
             // replace the one bnode ref with the object
-            predicate.set(predicate.lastIndexOf(id), object);
+            predicate.set(predicate.lastIndexOf(stringListEntry.getKey()), object);
         }
 
         // replace the rest of the collections
-        for (final String id : collections.keySet()) {
-            final Map<String, List<Object>> subj = ttl.get(id);
+        for (final Entry<String, List<Object>> stringListEntry : collections.entrySet()) {
+            final Map<String, List<Object>> subj = ttl.get(stringListEntry.getKey());
             if (!subj.containsKey(COLS_KEY)) {
                 subj.put(COLS_KEY, new ArrayList<Object>());
             }
-            subj.get(COLS_KEY).add(collections.get(id));
+            subj.get(COLS_KEY).add(stringListEntry.getValue());
         }
 
         // build turtle output
@@ -361,11 +361,11 @@ public class TurtleTripleCallback implements JsonLdTripleCallback {
             // return the bnode id
             return uri;
         }
-        for (final String prefix : availableNamespaces.keySet()) {
-            if (uri.startsWith(prefix)) {
-                usedNamespaces.add(prefix);
+        for (final Entry<String, String> stringStringEntry : availableNamespaces.entrySet()) {
+            if (uri.startsWith(stringStringEntry.getKey())) {
+                usedNamespaces.add(stringStringEntry.getKey());
                 // return the prefixed URI
-                return availableNamespaces.get(prefix) + ":" + uri.substring(prefix.length());
+                return stringStringEntry.getValue() + ":" + uri.substring(stringStringEntry.getKey().length());
             }
         }
         // return the full URI

--- a/karma-spark/src/main/java/edu/isi/karma/spark/KarmaDriver.java
+++ b/karma-spark/src/main/java/edu/isi/karma/spark/KarmaDriver.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.cli.BasicParser;
@@ -180,8 +181,8 @@ public class KarmaDriver {
             public Iterable<Tuple2<String, String>> call(Tuple2<String, String> writableIterableTuple2) throws Exception {
                 List<Tuple2<String, String>> results = new LinkedList<>();
                 Properties karmaContentSettings = new Properties();
-                for(Object key: karmaSettings.keySet())
-                	karmaContentSettings.put(key, karmaSettings.get(key));
+                for(Map.Entry<Object, Object> objectObjectEntry : karmaSettings.entrySet())
+                	karmaContentSettings.put(objectObjectEntry.getKey(), objectObjectEntry.getValue());
                 karmaContentSettings.put("model.content", model.value());
                 karmaContentSettings.put("context.content", context.getValue());
                 

--- a/karma-web/src/main/java/edu/isi/karma/linkedapi/server/PostRequestManager.java
+++ b/karma-web/src/main/java/edu/isi/karma/linkedapi/server/PostRequestManager.java
@@ -107,8 +107,8 @@ public class PostRequestManager extends LinkedApiRequestManager {
 			return false;
 		
 		for (Map<String, String> m : listOfInputAttValues)
-			for (String s : m.keySet())
-				logger.debug(s + "-->" + m.get(s));
+			for (Map.Entry<String, String> stringStringEntry : m.entrySet())
+				logger.debug(stringStringEntry.getKey() + "-->" + stringStringEntry.getValue());
 		
 		//for (String s : serviceIdsAndMappings.)
 		return true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.