### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/GradientDecendOptimizer.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/GradientDecendOptimizer.java
@@ -198,7 +198,7 @@ public class GradientDecendOptimizer {
 				{
 					offset += individualExps.get(x).size();
 				}
-				offset = offset/ (individualExps.size());
+				offset = offset/ individualExps.size();
 				//String sx = String.format("s: %d, t: %d,nG: %f, relative: %f, offset:%f", s.size(), t.size(),(negtiveCnt*1.0/gradient.length), this.relativeCoef,offset );
 			}
 			int wcnt = 0;

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/er/helper/ExportCSVUtil.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/er/helper/ExportCSVUtil.java
@@ -88,9 +88,9 @@ public class ExportCSVUtil {
 			if (prefObject != null) {
 				namespace = prefObject.getString(PreferencesKeys.rdfNamespace.name());
 				prefix = prefObject.getString(PreferencesKeys.rdfPrefix.name());
-				namespace = ((namespace == null) || (namespace.equals(""))) ? 
+				namespace = (namespace == null || namespace.equals("")) ? 
 						Namespaces.KARMA_DEV : namespace;
-				prefix = ((prefix == null) || (prefix.equals(""))) ? 
+				prefix = (prefix == null || prefix.equals("")) ? 
 						Prefixes.KARMA_DEV : prefix;
 			} else {
 				namespace = Namespaces.KARMA_DEV;

--- a/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/GlueCommand.java
+++ b/karma-commands/commands-worksheet/src/main/java/edu/isi/karma/controller/command/worksheet/GlueCommand.java
@@ -103,7 +103,7 @@ public class GlueCommand extends WorksheetSelectionCommand {
 			ht = oldws.getHeaders();
 		
 		for (int i = 0; i < checked.length(); i++) {
-			JSONObject t = (checked.getJSONObject(i));
+			JSONObject t = checked.getJSONObject(i);
 			HNode hNode = ht.getHNode(t.getString("value"));
 			if(i == 0)
 				this.hNodeParentName = hNode.getParentColumnName(factory);

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/Fact.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/Fact.java
@@ -21,11 +21,11 @@ public class Fact extends WeightedLabeledEdge<Entity, Relation, Float> implement
   public int compareTo(Fact o) {
     if(n1.compareTo(o.n1)!=0) return(n1.compareTo(o.n1));
     if(n2.compareTo(o.n2)!=0) return(n2.compareTo(o.n2));    
-    return(label.compareTo(o.label));
+    return label.compareTo(o.label);
   }
   
   public boolean equals(Object obj){
-	  return(this.compareTo((Fact)obj)==0);
+	  return this.compareTo((Fact)obj)==0;
   }
 
 }

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/Graph.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/Graph.java
@@ -29,7 +29,7 @@ public class Graph<V, E extends Edge<V>> {
 	
 	public HashSet<E> edges () { return edges; }
 
-	public HashSet<V> nodes () { return (new HashSet<V> (nodes.values())); }
+	public HashSet<V> nodes () { return new HashSet<V> (nodes.values()); }
 	
 	public void addNode (V v) {
 		nodes.put(v.toString(), v);
@@ -67,7 +67,7 @@ public class Graph<V, E extends Edge<V>> {
 	}*/
 	
 	public String toString () {
-    if(edges.size()==0) return("<Empty graph>");
+    if(edges.size()==0) return "<Empty graph>";
     StringBuilder b=new StringBuilder();
     Set<Edge> goodEdges = new TreeSet<Edge>();
     Set<Edge> badEdges = new TreeSet<Edge>();
@@ -80,6 +80,6 @@ public class Graph<V, E extends Edge<V>> {
       b.append(e).append('\n');
     }
     b.setLength(b.length()-1);
-		return(b.toString());
+		return b.toString();
 	}
 }

--- a/karma-common/src/main/java/edu/isi/karma/rep/model/Model.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/model/Model.java
@@ -365,7 +365,7 @@ public class Model {
 			Atom atom = this.getAtoms().get(i);
 			if (atom != null) {
 				if (atom instanceof ClassAtom) {
-					ClassAtom classAtom = ((ClassAtom)atom);
+					ClassAtom classAtom = (ClassAtom)atom;
 					
 					if (classAtom.getClassPredicate().getPrefix() != null &&
 							classAtom.getClassPredicate().getNs() != null) { 
@@ -390,7 +390,7 @@ public class Model {
 						"      " + argument1Var + " rdf:type " + predicateUri + " . \n";
 				}
 				else if (atom instanceof IndividualPropertyAtom) {
-					IndividualPropertyAtom propertyAtom = ((IndividualPropertyAtom)atom);
+					IndividualPropertyAtom propertyAtom = (IndividualPropertyAtom)atom;
 					
 					if (propertyAtom.getPropertyPredicate().getPrefix() != null &&
 							propertyAtom.getPropertyPredicate().getNs() != null) { 
@@ -461,7 +461,7 @@ public class Model {
 			Atom atom = this.getAtoms().get(i);
 			if (atom != null) {
 				if (atom instanceof ClassAtom) {
-					ClassAtom classAtom = ((ClassAtom)atom);
+					ClassAtom classAtom = (ClassAtom)atom;
 					
 					if (classAtom.getClassPredicate().getPrefix() != null &&
 							classAtom.getClassPredicate().getNs() != null) { 
@@ -487,7 +487,7 @@ public class Model {
 						"      " + argument1Var + " rdf:type " + predicateUri + " . \n";
 				}
 				else if (atom instanceof IndividualPropertyAtom) {
-					IndividualPropertyAtom propertyAtom = ((IndividualPropertyAtom)atom);
+					IndividualPropertyAtom propertyAtom = (IndividualPropertyAtom)atom;
 					
 					if (propertyAtom.getPropertyPredicate().getPrefix() != null &&
 							propertyAtom.getPropertyPredicate().getNs() != null) { 
@@ -585,7 +585,7 @@ public class Model {
 			Atom atom = m.getAtoms().get(i);
 			if (atom != null) {
 				if (atom instanceof ClassAtom) {
-					ClassAtom classAtom = ((ClassAtom)atom);
+					ClassAtom classAtom = (ClassAtom)atom;
 					atomVar = "?atom" + String.valueOf(i+1);
 					predicateUri = classAtom.getClassPredicate().getUri();
 					argument1 = classAtom.getArgument1().getId();
@@ -603,7 +603,7 @@ public class Model {
 						"      " + atomVar + " " + Prefixes.SWRL + ":argument1 " + argument1Var + " . \n";
 				}
 				else if (atom instanceof IndividualPropertyAtom) {
-					IndividualPropertyAtom propertyAtom = ((IndividualPropertyAtom)atom);
+					IndividualPropertyAtom propertyAtom = (IndividualPropertyAtom)atom;
 					atomVar = "?atom" + String.valueOf(i+1);
 					predicateUri = propertyAtom.getPropertyPredicate().getUri();
 					argument1 = propertyAtom.getArgument1().getId();
@@ -647,7 +647,7 @@ public class Model {
 		for (Atom atom : atoms) {
 			if (atom != null) {
 				if (atom instanceof ClassAtom) {
-					ClassAtom classAtom = ((ClassAtom)atom);
+					ClassAtom classAtom = (ClassAtom)atom;
 					logicalForm += classAtom.getClassPredicate().getLocalName();
 					logicalForm += "(";
 					logicalForm += classAtom.getArgument1().getId();
@@ -655,7 +655,7 @@ public class Model {
 					logicalForm += separator;				
 				}
 				else if (atom instanceof IndividualPropertyAtom) {
-					IndividualPropertyAtom propertyAtom = ((IndividualPropertyAtom)atom);
+					IndividualPropertyAtom propertyAtom = (IndividualPropertyAtom)atom;
 					logicalForm += propertyAtom.getPropertyPredicate().getLocalName();
 					logicalForm += "(";
 					logicalForm += propertyAtom.getArgument1().getId();

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -180,7 +180,7 @@ public class JsonLdApi {
                 }
             }
             // 5)
-            final boolean insideReverse = ("@reverse".equals(activeProperty));
+            final boolean insideReverse = "@reverse".equals(activeProperty);
 
             // 6)
             final Map<String, Object> result = newMap();

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
@@ -713,8 +713,8 @@ public class JsonLdUtils {
         // filter out value
         final List<Object> values = new ArrayList<Object>();
         if (subject.get(property) instanceof List) {
-            for (final Object e : ((List) subject.get(property))) {
-                if (!(value.equals(e))) {
+            for (final Object e : (List) subject.get(property)) {
+                if (!value.equals(e)) {
                     values.add(value);
                 }
             }
@@ -826,7 +826,7 @@ public class JsonLdUtils {
                     }
                 }
             }
-            return (count < urls.size());
+            return count < urls.size();
         }
         return false;
     }
@@ -854,7 +854,7 @@ public class JsonLdUtils {
                 // and means that
                 // the input JSON-LD is invalid
                 throw new RuntimeException(new CloneNotSupportedException(
-                        (rval instanceof Exception ? ((Exception) rval).getMessage() : "")));
+                        rval instanceof Exception ? ((Exception) rval).getMessage() : ""));
             }
         }
         return rval;
@@ -868,7 +868,7 @@ public class JsonLdUtils {
      * @return
      */
     static Boolean isArray(Object v) {
-        return (v instanceof List);
+        return v instanceof List;
     }
 
     /**
@@ -879,7 +879,7 @@ public class JsonLdUtils {
      * @return
      */
     static Boolean isList(Object v) {
-        return (v instanceof Map && ((Map<String, Object>) v).containsKey("@list"));
+        return v instanceof Map && ((Map<String, Object>) v).containsKey("@list");
     }
 
     /**
@@ -890,7 +890,7 @@ public class JsonLdUtils {
      * @return
      */
     static Boolean isObject(Object v) {
-        return (v instanceof Map);
+        return v instanceof Map;
     }
 
     /**
@@ -901,7 +901,7 @@ public class JsonLdUtils {
      * @return
      */
     static Boolean isValue(Object v) {
-        return (v instanceof Map && ((Map<String, Object>) v).containsKey("@value"));
+        return v instanceof Map && ((Map<String, Object>) v).containsKey("@value");
     }
 
     /**
@@ -913,6 +913,6 @@ public class JsonLdUtils {
      */
     static Boolean isString(Object v) {
         // TODO: should this return true for arrays of strings as well?
-        return (v instanceof String);
+        return v instanceof String;
     }
 }

--- a/karma-offline/src/main/java/edu/isi/karma/rdf/JSONImpl.java
+++ b/karma-offline/src/main/java/edu/isi/karma/rdf/JSONImpl.java
@@ -36,7 +36,7 @@ public class JSONImpl extends BaseRDFImpl {
         KR2RMLRDFWriter outWriter = new JSONKR2RMLRDFWriter(pw, karma.getBaseURI(), disableNesting);
         ContextIdentifier contextId = karma.getContextId();
         try {
-            atId = getAtId(karma.getGenerator().loadContext(contextId).getJSONObject(("@context")));
+            atId = getAtId(karma.getGenerator().loadContext(contextId).getJSONObject("@context"));
         } catch(Exception e)
         {}
         return outWriter;

--- a/karma-offline/src/main/java/edu/isi/karma/rdf/OfflineRdfGenerator.java
+++ b/karma-offline/src/main/java/edu/isi/karma/rdf/OfflineRdfGenerator.java
@@ -150,7 +150,7 @@ public class OfflineRdfGenerator {
 			generator.generate();
 			long end = System.currentTimeMillis();
 			
-			logger.info("Time to generate RDF:" + ((float)(end-start))/(1000*60) + " mins");
+			logger.info("Time to generate RDF:" + (float) (end-start) /(1000*60) + " mins");
 
 		} catch (Exception e) {
 			logger.error("Error occured while generating RDF!", e);
@@ -181,7 +181,7 @@ public class OfflineRdfGenerator {
 			generateRdfFromFile();
 		}
 
-		logger.info("done after {}", (System.currentTimeMillis() - l));
+		logger.info("done after {}", System.currentTimeMillis() - l);
 		if(outputFilePath != null)
 		{
 			logger.info("RDF published at: " + outputFilePath);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.