### PR TITLE
Subclasses that add fields should override "equals"

### DIFF
--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/ContextGenerator.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/ContextGenerator.java
@@ -163,4 +163,25 @@ public class ContextGenerator {
 		top.put("@context", obj);
 		return top;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || this.getClass() != o.getClass()) return false;
+
+		ContextGenerator that = (ContextGenerator) o;
+
+		if (this.isGenerateAtIdType != that.isGenerateAtIdType) return false;
+		if (this.model != null ? !this.model.equals(that.model) : that.model != null) return false;
+		return this.contextMapping != null ? this.contextMapping.equals(that.contextMapping) : that.contextMapping == null;
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = this.model != null ? this.model.hashCode() : 0;
+		result = 31 * result + (this.isGenerateAtIdType ? 1 : 0);
+		result = 31 * result + (this.contextMapping != null ? this.contextMapping.hashCode() : 0);
+		return result;
+	}
 }

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/Context.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/Context.java
@@ -1120,4 +1120,27 @@ public class Context extends LinkedHashMap<String, Object> {
         return rval;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        Context context = (Context) o;
+
+        if (this.options != null ? !this.options.equals(context.options) : context.options != null) return false;
+        if (this.termDefinitions != null ? !this.termDefinitions.equals(context.termDefinitions) : context.termDefinitions != null)
+            return false;
+        return this.inverse != null ? this.inverse.equals(context.inverse) : context.inverse == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (this.options != null ? this.options.hashCode() : 0);
+        result = 31 * result + (this.termDefinitions != null ? this.termDefinitions.hashCode() : 0);
+        result = 31 * result + (this.inverse != null ? this.inverse.hashCode() : 0);
+        return result;
+    }
 }

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -2090,4 +2090,32 @@ public class JsonLdApi {
         return normalizeUtils.hashBlankNodes(bnodes.keySet());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+
+        JsonLdApi jsonLdApi = (JsonLdApi) o;
+
+        if (this.opts != null ? !this.opts.equals(jsonLdApi.opts) : jsonLdApi.opts != null) return false;
+        if (this.value != null ? !this.value.equals(jsonLdApi.value) : jsonLdApi.value != null) return false;
+        if (this.context != null ? !this.context.equals(jsonLdApi.context) : jsonLdApi.context != null) return false;
+        if (this.blankNodeMapping != null ? !this.blankNodeMapping.equals(jsonLdApi.blankNodeMapping) : jsonLdApi.blankNodeMapping != null)
+            return false;
+        if (this.blankNodeIdentifierMap != null ? !this.blankNodeIdentifierMap.equals(jsonLdApi.blankNodeIdentifierMap) : jsonLdApi.blankNodeIdentifierMap != null)
+            return false;
+        return this.nodeMap != null ? this.nodeMap.equals(jsonLdApi.nodeMap) : jsonLdApi.nodeMap == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.opts != null ? this.opts.hashCode() : 0;
+        result = 31 * result + (this.value != null ? this.value.hashCode() : 0);
+        result = 31 * result + (this.context != null ? this.context.hashCode() : 0);
+        result = 31 * result + (this.blankNodeMapping != null ? this.blankNodeMapping.hashCode() : 0);
+        result = 31 * result + (this.blankNodeIdentifierMap != null ? this.blankNodeIdentifierMap.hashCode() : 0);
+        result = 31 * result + (this.nodeMap != null ? this.nodeMap.hashCode() : 0);
+        return result;
+    }
 }

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDataset.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDataset.java
@@ -688,4 +688,25 @@ public class RDFDataset extends LinkedHashMap<String, Object> {
     public List<Quad> getQuads(String graphName) {
         return (List<Quad>) get(graphName);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        RDFDataset that = (RDFDataset) o;
+
+        if (this.context != null ? !this.context.equals(that.context) : that.context != null) return false;
+        return this.api != null ? this.api.equals(that.api) : that.api == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (this.context != null ? this.context.hashCode() : 0);
+        result = 31 * result + (this.api != null ? this.api.hashCode() : 0);
+        return result;
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2160 - “Subclasses that add fields should override "equals"”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2160
Please let me know if you have any questions.
Ayman Abdelghany.