### PR TITLE
Classes that override "clone" should be "Cloneable"

### DIFF
--- a/karma-common/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
@@ -52,7 +52,7 @@ import java.util.*;
  * @author szekely
  * 
  */
-public class CommandHistory {
+public class CommandHistory implements Cloneable{
 
 	private WorksheetCommandHistory worksheetCommandHistory = new WorksheetCommandHistory();
 	private Command previewCommand;

--- a/karma-common/src/main/java/edu/isi/karma/controller/history/WorksheetCommandHistory.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/history/WorksheetCommandHistory.java
@@ -11,7 +11,7 @@ import java.util.*;
 /**
  * Created by Frank on 9/14/15.
  */
-public class WorksheetCommandHistory {
+public class WorksheetCommandHistory implements Cloneable {
 
     private class CommandTagListMap {
         private final Map<ICommand.CommandTag, List<ICommand> > commandTagListHashMap = new HashMap<>();

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/NodeIdFactory.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/NodeIdFactory.java
@@ -23,7 +23,7 @@ package edu.isi.karma.modeling.alignment;
 
 import java.util.HashMap;
 
-public class NodeIdFactory {
+public class NodeIdFactory implements Cloneable {
 
 	private HashMap<String, Integer> nodeUris = new HashMap<String, Integer>();
 	

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/ApprSteinerTree.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/ApprSteinerTree.java
@@ -18,7 +18,7 @@ import java.util.TreeSet;
  * @author kasneci
  *
  */
-public class ApprSteinerTree extends SteinerSubTree{
+public class ApprSteinerTree extends SteinerSubTree implements Cloneable {
 	
 	// all the nodes of the result tree
 	protected Set<SteinerNode> treeNodes;

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/LoosePath.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/LoosePath.java
@@ -14,7 +14,7 @@ import java.util.TreeSet;
  *
  */
 
-public class LoosePath extends SteinerSubTree {
+public class LoosePath extends SteinerSubTree implements Cloneable {
 	
 	//list of steiner nodes belonging to this loose path
 	protected LinkedList<SteinerNode> pathNodes;

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/SteinerSubTree.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/SteinerSubTree.java
@@ -11,7 +11,7 @@ import java.util.TreeSet;
  * @author kasneci
  *
  */
-public abstract class SteinerSubTree implements Comparable<SteinerSubTree>{
+public abstract class SteinerSubTree implements Comparable<SteinerSubTree>, Cloneable {
 
 	protected double score;
 	private Set<SteinerNode> nodes;

--- a/karma-common/src/main/java/edu/isi/karma/rep/alignment/Node.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/alignment/Node.java
@@ -31,7 +31,7 @@ import com.rits.cloning.Cloner;
 import edu.isi.karma.modeling.Uris;
 import edu.isi.karma.util.RandomGUID;
 
-public abstract class Node implements Comparable<Node> {
+public abstract class Node implements Comparable<Node>, Cloneable {
 
 	static Logger logger = LoggerFactory.getLogger(Node.class);
 

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/UniqueNamer.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/UniqueNamer.java
@@ -3,7 +3,7 @@ package com.github.jsonldjava.core;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class UniqueNamer {
+public class UniqueNamer implements Cloneable {
     private final String prefix;
     private int counter;
     private Map<String, String> existing;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1182 - “Classes that override "clone" should be "Cloneable"”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1182
Please let me know if you have any questions.
Ayman Abdelghany.