### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/LinearSolver.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/LinearSolver.java
@@ -12,6 +12,9 @@ import org.apache.commons.math.optimization.linear.Relationship;
 import org.apache.commons.math.optimization.linear.SimplexSolver;
 
 public class LinearSolver {
+	private LinearSolver() {
+	}
+
 	public static void main(String[] args) {
 		//add residue to objective function
 		LinearObjectiveFunction f = new LinearObjectiveFunction(new double[] {-3,-3,4,0,0,0

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgTracker.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ProgTracker.java
@@ -4,6 +4,9 @@ import java.util.Map;
 import java.util.Vector;
 
 public class ProgTracker {
+	private ProgTracker() {
+	}
+
 	public static void printPartition(Vector<Partition> pars) {
 		System.out.println("-----------");
 		System.out.println("CURRENT_PARS" + pars.toString());

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/SegmentMapper.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/SegmentMapper.java
@@ -18,6 +18,9 @@ class Dataitem {
 public class SegmentMapper {
 	public static InternalTransformationLibrary itfl = new InternalTransformationLibrary();
 
+	private SegmentMapper() {
+	}
+
 	// only try to find one segment whose starting pos in target is pos
 	public static Vector<Segment> findMapping(Vector<TNode> org,
 			Vector<TNode> tar, int pos) {

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/UtilTools.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/UtilTools.java
@@ -25,6 +25,9 @@ public class UtilTools {
 	public static int index = 0;
 	public static Vector<String> results = new Vector<String>();
 
+	private UtilTools() {
+	}
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static Map sortByComparator(Map unsortMap) {
 		List list = new LinkedList(unsortMap.entrySet());

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
@@ -16,6 +16,9 @@ public class Data2Features {
 
 	private static Logger logger = LoggerFactory.getLogger(Data2Features.class);
 
+	private Data2Features() {
+	}
+
 	// convert the csv file to arff file
 	// return the fpath of arff file
 	/*

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetUpdateFactory.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetUpdateFactory.java
@@ -36,6 +36,9 @@ import edu.isi.karma.rep.Workspace;
 
 public class WorksheetUpdateFactory {
 
+	private WorksheetUpdateFactory() {
+	}
+
 	public static UpdateContainer createWorksheetHierarchicalAndCleaningResultsUpdates(String worksheetId, SuperSelection sel, String contextId) {
 		UpdateContainer c = new UpdateContainer();
 		createWorksheetHierarchicalAndCleaningResultsUpdates(worksheetId, c, sel, contextId);

--- a/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/SpatialReferenceSystemTransformationUtil.java
+++ b/karma-commands/commands-import/import-spatial/src/main/java/edu/isi/karma/geospatial/SpatialReferenceSystemTransformationUtil.java
@@ -41,7 +41,7 @@ public class SpatialReferenceSystemTransformationUtil {
 	private static final Logger logger = LoggerFactory
 			.getLogger(SpatialReferenceSystemTransformationUtil.class);
 
-	public SpatialReferenceSystemTransformationUtil() {
+	private SpatialReferenceSystemTransformationUtil() {
 
 	}
 

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/er/helper/ExportCSVUtil.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/er/helper/ExportCSVUtil.java
@@ -53,6 +53,9 @@ public class ExportCSVUtil {
 
 	private static Logger logger = LoggerFactory.getLogger(ExportCSVUtil.class);
 
+	private ExportCSVUtil() {
+	}
+
 	/**
 	 * @author shri
 	 * 

--- a/karma-commands/commands-python/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetHistoryCompatibilityVerifier.java
+++ b/karma-commands/commands-python/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetHistoryCompatibilityVerifier.java
@@ -24,6 +24,10 @@ public class KR2RMLWorksheetHistoryCompatibilityVerifier {
 
 	private static Logger logger = LoggerFactory
 			.getLogger(KR2RMLWorksheetHistoryCompatibilityVerifier.class);
+
+	private KR2RMLWorksheetHistoryCompatibilityVerifier() {
+	}
+
 	public static boolean verify(Workspace workspace, String historyJsonStr) {
 		boolean isR2RMLCompatible = true;
 		if(null != historyJsonStr && !historyJsonStr.isEmpty())

--- a/karma-commands/commands-python/src/main/java/edu/isi/karma/transformation/tokenizer/PythonTransformationAsURITokenizer.java
+++ b/karma-commands/commands-python/src/main/java/edu/isi/karma/transformation/tokenizer/PythonTransformationAsURITokenizer.java
@@ -29,6 +29,10 @@ public class PythonTransformationAsURITokenizer {
 		}
 		
 	}
+
+	private PythonTransformationAsURITokenizer() {
+	}
+
 	public static List<PythonTransformationToken> tokenize(PythonTransformationCommand command)
 	{
 		return tokenize(command.getTransformationCode());

--- a/karma-common/src/main/java/edu/isi/karma/common/OSUtils.java
+++ b/karma-common/src/main/java/edu/isi/karma/common/OSUtils.java
@@ -3,7 +3,10 @@ package edu.isi.karma.common;
 public class OSUtils {
 
 	private static String OS = null;
-	
+
+	private OSUtils() {
+	}
+
 	public static String getOsName() {
 		if(OS == null) { OS = System.getProperty("os.name"); }
 		//System.out.println("OS:" + OS);

--- a/karma-common/src/main/java/edu/isi/karma/controller/command/service/ServiceTableUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/command/service/ServiceTableUtil.java
@@ -43,7 +43,10 @@ public class ServiceTableUtil {
 
 	private static Logger logger = LoggerFactory.getLogger(ServiceTableUtil.class);
 
-	
+	private ServiceTableUtil() {
+	}
+
+
 	public static void populateEmptyWorksheet(Table table, Worksheet worksheet, RepFactory factory) {
 
 		logger.info("Populating an empty worksheet with the service data ...");

--- a/karma-common/src/main/java/edu/isi/karma/controller/history/HistoryJsonUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/history/HistoryJsonUtil.java
@@ -11,7 +11,10 @@ import edu.isi.karma.controller.command.ICommand.CommandTag;
 import edu.isi.karma.controller.history.CommandHistory.HistoryArguments;
 
 public class HistoryJsonUtil {
-	
+
+	private HistoryJsonUtil() {
+	}
+
 	public enum ClientJsonKeys {
 		isPrimary, name, value, type, SemanticType, id, children
 	}

--- a/karma-common/src/main/java/edu/isi/karma/er/helper/CloneTableUtils.java
+++ b/karma-common/src/main/java/edu/isi/karma/er/helper/CloneTableUtils.java
@@ -16,7 +16,10 @@ import edu.isi.karma.rep.Table;
 import edu.isi.karma.rep.Worksheet;
 
 public class CloneTableUtils {
-	
+
+	private CloneTableUtils() {
+	}
+
 	public static Map<String, String> cloneHTable(HTable newHTable, Worksheet newWorksheet, RepFactory factory, List<HNode> hNodes, boolean isFirst) {
 		Collections.sort(hNodes);
 		Map<String, String> tmp = new HashMap<>();

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/formatter/KR2RMLColumnNameFormatterFactory.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/formatter/KR2RMLColumnNameFormatterFactory.java
@@ -24,6 +24,9 @@ import edu.isi.karma.rep.metadata.WorksheetProperties.SourceTypes;
 
 public class KR2RMLColumnNameFormatterFactory {
 
+	private KR2RMLColumnNameFormatterFactory() {
+	}
+
 	public static KR2RMLColumnNameFormatter getFormatter(SourceTypes sourceType)
 	{
 		switch(sourceType)

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/template/TemplateTermSetBuilder.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/template/TemplateTermSetBuilder.java
@@ -35,7 +35,10 @@ import edu.isi.karma.rep.metadata.WorksheetProperties.SourceTypes;
 public class TemplateTermSetBuilder {
 
 	private static Logger logger = LoggerFactory.getLogger(TemplateTermSetBuilder.class);
-	
+
+	private TemplateTermSetBuilder() {
+	}
+
 	public static TemplateTermSet constructTemplateTermSetFromR2rmlTemplateString(
 			String templStr) throws JSONException {
 		return constructTemplateTermSetFromR2rmlTemplateString(templStr, KR2RMLColumnNameFormatterFactory.getFormatter(SourceTypes.CSV));

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphUtil.java
@@ -74,6 +74,9 @@ public class GraphUtil {
 
 	private static Logger logger = LoggerFactory.getLogger(GraphUtil.class);
 
+	private GraphUtil() {
+	}
+
 	public static DirectedGraph<Node, DefaultLink> asDirectedGraph(UndirectedGraph<Node, DefaultLink> undirectedGraph) {
 		
 		if (undirectedGraph == null) {

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphVizUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphVizUtil.java
@@ -47,6 +47,9 @@ public class GraphVizUtil {
 
 	private static Logger logger = LoggerFactory.getLogger(GraphVizUtil.class);
 
+	private GraphVizUtil() {
+	}
+
 	private static double roundDecimals(double d, int k) {
 		String format = "";
 		for (int i = 0; i < k; i++) format += "#";

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/learner/ModelReader.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/learner/ModelReader.java
@@ -30,6 +30,9 @@ import edu.isi.karma.modeling.research.Params;
 
 public class ModelReader {
 
+	private ModelReader() {
+	}
+
 	public static void main(String[] args) throws Exception {
 		
 		List<SemanticModel> semanticModels = null;

--- a/karma-common/src/main/java/edu/isi/karma/rep/HashValueManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/HashValueManager.java
@@ -12,7 +12,10 @@ import edu.isi.karma.controller.command.selection.SuperSelectionManager;
 
 public class HashValueManager {
 	private static Map<String, Map<String, String>> hashTable = new ConcurrentHashMap<String, Map<String, String>>();
-	
+
+	private HashValueManager() {
+	}
+
 	private static void computeHashValue(Row row, List<String> HNodeIds) {
 		for (String HNodeid : HNodeIds) {
 			Node n = row.getNode(HNodeid);

--- a/karma-common/src/main/java/edu/isi/karma/rep/sources/URLManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/sources/URLManager.java
@@ -41,7 +41,7 @@ public class URLManager {
 
 	static Logger logger = LoggerFactory.getLogger(URLManager.class);
 
-	public URLManager() {
+	private URLManager() {
 		
 	}
 

--- a/karma-common/src/main/java/edu/isi/karma/service/json/JsonManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/service/json/JsonManager.java
@@ -44,7 +44,10 @@ import edu.isi.karma.rep.sources.Table;
 
 public class JsonManager {
 
-    public static String readFile(File file) throws IOException {
+	private JsonManager() {
+	}
+
+	public static String readFile(File file) throws IOException {
     	InputStream in = new FileInputStream(file);
     	byte[] b  = new byte[(int)file.length()];
     	int len = b.length;

--- a/karma-common/src/main/java/edu/isi/karma/util/CommandInputJSONUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/CommandInputJSONUtil.java
@@ -10,7 +10,10 @@ import edu.isi.karma.controller.history.HistoryJsonUtil.ParameterType;
 
 
 public class CommandInputJSONUtil {
-	
+
+	private CommandInputJSONUtil() {
+	}
+
 	public enum JsonKeys {
 		name, value, type
 	}

--- a/karma-common/src/main/java/edu/isi/karma/util/EncodingDetector.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/EncodingDetector.java
@@ -20,6 +20,9 @@ public class EncodingDetector {
 	private static Logger logger = LoggerFactory.getLogger(EncodingDetector.class);
     public final static String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
+    private EncodingDetector() {
+    }
+
     public static String detect(InputStream is) throws IOException {
 
         byte[] buf = new byte[4096];

--- a/karma-common/src/main/java/edu/isi/karma/util/FileUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/FileUtil.java
@@ -53,6 +53,9 @@ public class FileUtil {
 
 	private static Logger logger = LoggerFactory.getLogger(FileUtil.class);
 
+    private FileUtil() {
+    }
+
     static public File downloadFileFromHTTPRequest(HttpServletRequest request, String destinationDirString) {
         // Download the file to the upload file folder
     	

--- a/karma-common/src/main/java/edu/isi/karma/util/HTTPUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/HTTPUtil.java
@@ -45,6 +45,9 @@ import org.json.XML;
 
 
 public class HTTPUtil {
+	private HTTPUtil() {
+	}
+
 	public enum HTTP_METHOD {
 		GET, POST, PUT, DELETE, HEAD
 	}

--- a/karma-common/src/main/java/edu/isi/karma/util/JSONLDUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/JSONLDUtil.java
@@ -11,7 +11,10 @@ public class JSONLDUtil {
 	static {
 		comparator =  new JSONLDReducerComparator();
 	}
-	
+
+	private JSONLDUtil() {
+	}
+
 	public static JSONObject mergeJSONObjects(Iterator<String> iterator) {
 
 		JSONObject accumulatorObject = new JSONObject();

--- a/karma-common/src/main/java/edu/isi/karma/util/JSONUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/JSONUtil.java
@@ -40,6 +40,9 @@ public class JSONUtil {
 
 	private static Logger logger = LoggerFactory.getLogger(JSONUtil.class);
 
+	private JSONUtil() {
+	}
+
 	public static String enclose(String x, String delimiter) {
 		return delimiter + x + delimiter;
 	}

--- a/karma-common/src/main/java/edu/isi/karma/util/Util.java
+++ b/karma-common/src/main/java/edu/isi/karma/util/Util.java
@@ -32,6 +32,9 @@ import java.util.TreeSet;
 import org.slf4j.Logger;
 
 public class Util {
+	private Util() {
+	}
+
 	/**
 	 * Sorts a HashMap based on the values with Double data type
 	 * 

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdProcessor.java
@@ -26,6 +26,9 @@ import com.github.jsonldjava.impl.TurtleTripleCallback;
  */
 public class JsonLdProcessor {
 
+    private JsonLdProcessor() {
+    }
+
     /**
      * Compacts the given input using the context according to the steps in the
      * <a href="http://www.w3.org/TR/json-ld-api/#compaction-algorithm">

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/JsonLdUtils.java
@@ -16,6 +16,9 @@ public class JsonLdUtils {
 
     private static final int MAX_CONTEXT_URLS = 10;
 
+    private JsonLdUtils() {
+    }
+
     /**
      * Returns whether or not the given value is a keyword (or a keyword alias).
      *

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDatasetUtils.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/core/RDFDatasetUtils.java
@@ -13,6 +13,9 @@ import static com.github.jsonldjava.utils.Obj.newMap;
 
 public class RDFDatasetUtils {
 
+    private RDFDatasetUtils() {
+    }
+
     /**
      * Creates an array of RDF triples for the given graph.
      *

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/impl/TurtleRDFParser.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/impl/TurtleRDFParser.java
@@ -94,6 +94,9 @@ public class TurtleRDFParser implements RDFParser {
 
         final public static Pattern COMMENT_OR_WS = Pattern.compile("^(?:(?:[#].*(?:" + EOLN + ")"
                 + WS_0_N + ")|(?:" + WS_1_N + "))");
+
+        private Regex() {
+        }
     }
 
     private class State {

--- a/karma-jsonld/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
+++ b/karma-jsonld/src/main/java/com/github/jsonldjava/utils/JsonUtils.java
@@ -49,6 +49,9 @@ public class JsonUtils {
         JSON_FACTORY.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
     }
 
+    private JsonUtils() {
+    }
+
     /**
      * Parses a JSON-LD document from the given {@link InputStream} to an object
      * that can be used as input for the {@link JsonLdApi} and

--- a/karma-mr/src/main/java/edu/isi/karma/mapreduce/tripleparser/TripleProcessor.java
+++ b/karma-mr/src/main/java/edu/isi/karma/mapreduce/tripleparser/TripleProcessor.java
@@ -19,6 +19,9 @@ public class TripleProcessor {
 
 	private final static Logger logger = LoggerFactory.getLogger(TripleProcessor.class);
 
+	private TripleProcessor() {
+	}
+
 	public static void parseTriples(Configuration conf, Path input, Path output) throws IOException {
 
 		FileSystem fs = FileSystem.get(conf);

--- a/karma-offline/src/main/java/edu/isi/karma/rdf/CommandLineArgumentParser.java
+++ b/karma-offline/src/main/java/edu/isi/karma/rdf/CommandLineArgumentParser.java
@@ -11,7 +11,10 @@ import org.slf4j.LoggerFactory;
 public class CommandLineArgumentParser {
 
 	private static Logger logger = LoggerFactory.getLogger(CommandLineArgumentParser.class);
-	
+
+	private CommandLineArgumentParser() {
+	}
+
 	public static CommandLine parse(String args[], Options options, String commandName)
 	{
 		CommandLineParser parser = new BasicParser();

--- a/karma-spark/src/main/java/edu/isi/karma/spark/JSONContextDriver.java
+++ b/karma-spark/src/main/java/edu/isi/karma/spark/JSONContextDriver.java
@@ -34,7 +34,10 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 public class JSONContextDriver {
 private static Logger logger = LoggerFactory.getLogger(JSONContextDriver.class);
-    
+
+    private JSONContextDriver() {
+    }
+
     public static void main(String[] args) throws ParseException, IOException, ClassNotFoundException {
     	int defaultPartitions = 100;
     	

--- a/karma-spark/src/main/java/edu/isi/karma/spark/JSONReducerDriver.java
+++ b/karma-spark/src/main/java/edu/isi/karma/spark/JSONReducerDriver.java
@@ -28,7 +28,10 @@ import edu.isi.karma.util.JSONLDUtil;
 
 public class JSONReducerDriver {
 	private static Logger logger = LoggerFactory.getLogger(JSONReducerDriver.class);
-    
+
+    private JSONReducerDriver() {
+    }
+
     public static void main(String[] args) throws ParseException, IOException, ClassNotFoundException {
     	int defaultPartitions = 100;
     	

--- a/karma-spark/src/main/java/edu/isi/karma/spark/KarmaDriver.java
+++ b/karma-spark/src/main/java/edu/isi/karma/spark/KarmaDriver.java
@@ -43,8 +43,11 @@ import edu.isi.karma.util.JSONLDUtil;
  */
 public class KarmaDriver {
     private static Logger logger = LoggerFactory.getLogger(KarmaDriver.class);
-    
-    public static void main(String[] args) throws ParseException, IOException, ClassNotFoundException {
+
+	private KarmaDriver() {
+	}
+
+	public static void main(String[] args) throws ParseException, IOException, ClassNotFoundException {
     	int defaultPartitions = 100;
     	final int batchSize = 200;
     	

--- a/karma-util/src/main/java/edu/isi/karma/common/ResourceUtils.java
+++ b/karma-util/src/main/java/edu/isi/karma/common/ResourceUtils.java
@@ -13,6 +13,9 @@ import org.apache.commons.io.IOUtils;
  */
 public class ResourceUtils {
 
+	private ResourceUtils() {
+	}
+
 	public static List<String> getListOfFiles(String classpathPath) throws IOException {
 		InputStream resourceAsStream = ResourceUtils.class.getClassLoader().getResourceAsStream("csv/");
 		return IOUtils.readLines(resourceAsStream);

--- a/karma-web/src/main/java/edu/isi/karma/webserver/SampleDataFactory.java
+++ b/karma-web/src/main/java/edu/isi/karma/webserver/SampleDataFactory.java
@@ -50,6 +50,9 @@ public class SampleDataFactory {
 	private static Logger logger = LoggerFactory
 			.getLogger(SampleDataFactory.class);
 
+	private SampleDataFactory() {
+	}
+
 	public static Worksheet createSample1(Workspace workspace) {
 		RepFactory f = workspace.getFactory();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.