### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Correctness/FormatFunc.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Correctness/FormatFunc.java
@@ -86,7 +86,7 @@ public class FormatFunc implements VerificationFunc {
 		//difference STRICTLY bigger than 2 standard deviations [68, 95, 99.7] rule
 		if(Math.abs(dist - mean_var.get(record.label)[0]) > 2.0*mean_var.get(record.label)[1])
 		{
-			return this.funid+"";
+			return String.valueOf(this.funid);
 		}
 		return "0";
 	}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Correctness/ViewFunc.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Correctness/ViewFunc.java
@@ -104,7 +104,7 @@ public class ViewFunc implements VerificationFunc {
 				equviViews.add(lviews);
 			}
 			cnt++;
-			views.put(cnt+"", equviViews);
+			views.put(String.valueOf(cnt), equviViews);
 		}
 		
 		

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/QuestionableRecord/Feature2.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/QuestionableRecord/Feature2.java
@@ -39,7 +39,7 @@ public class Feature2 implements RecFeature {
 	}
 
 	public String getName() {
-		return type + "";
+		return String.valueOf(type);
 	}
 
 	public double computerScore() {

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/MultipleStringAlign.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/MultipleStringAlign.java
@@ -103,18 +103,18 @@ public class MultipleStringAlign {
 		if (pos >= tar.length())
 			return segs;
 		String tmp = "";
-		tmp += tar.charAt(pos);
+		tmp += String.valueOf(tar.charAt(pos));
 		int q = org.indexOf(tmp);
 		if (q == -1) {
 			int cnt = pos;
 			String tvec = "";
 			while (q == -1) {
-				tvec += tar.charAt(cnt);
+				tvec += String.valueOf(tar.charAt(cnt));
 				cnt++;
 				tmp = "";
 				if (cnt >= tar.length())
 					break;
-				tmp += tar.charAt(cnt);
+				tmp += String.valueOf(tar.charAt(cnt));
 				q = org.indexOf(tmp);
 			}
 			int[] elem = { -1, cnt - pos };
@@ -124,7 +124,7 @@ public class MultipleStringAlign {
 		for (int i = pos; i < tar.length(); i++) {
 			String tvec = "";
 			for (int j = pos; j <= i; j++) {
-				tvec += tar.charAt(j);
+				tvec += String.valueOf(tar.charAt(j));
 			}
 			Vector<Integer> mappings = new Vector<Integer>();
 			int r = org.indexOf(tvec);
@@ -151,10 +151,10 @@ public class MultipleStringAlign {
 					corrm.add(m);
 					segs.addAll(corrm);
 				} else {
-					tvec += tar.charAt(i + 1);
+					tvec += String.valueOf(tar.charAt(i + 1));
 					int p = org.indexOf(tvec, 0);
 					String repToken = "";
-					repToken += tar.charAt(i + 1);
+					repToken += String.valueOf(tar.charAt(i + 1));
 					int rind = 0;
 					int tokenCnt = 0;
 					while ((rind = org.indexOf(repToken, rind)) != -1) {

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/RecordDistiller.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/RecordDistiller.java
@@ -48,7 +48,7 @@ public class RecordDistiller {
 			if (curIndices.containsKey(type)) {
 				int cnt = curIndices.get(type);
 				curIndices.put(type, cnt + 1);
-				anchor += cnt;
+				anchor += String.valueOf(cnt);
 			} else {
 				curIndices.put(type, 0);
 				anchor += "0";
@@ -189,8 +189,8 @@ public class RecordDistiller {
 							break;
 						Ruler ruler = new Ruler();
 						ruler.setNewInput(pair[0]);
-						distiller.readRecord("" + id, ruler.vec);
-						id2String.put("" + id, pair[0]);
+						distiller.readRecord(String.valueOf(id), ruler.vec);
+						id2String.put(String.valueOf(id), pair[0]);
 						id++;
 					}
 					distiller.idenAnchor(id2String.keySet().size());
@@ -207,7 +207,7 @@ public class RecordDistiller {
 						}
 						System.out.println("\n");
 					}
-					System.out.println("" + compressRate);
+					System.out.println(String.valueOf(compressRate));
 				}
 			} catch (Exception e) {
 				System.out.println("" + e.toString());

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/TimerRunner.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/TimerRunner.java
@@ -52,7 +52,7 @@ public class TimerRunner implements Runnable {
 																			// tar,
 																			// tarcode,
 																			// label
-					xHashMap.put(index + "", line);
+					xHashMap.put(String.valueOf(index), line);
 					index++;
 				}
 				DataPreProcessor dpp = new DataPreProcessor(vtmp);
@@ -85,7 +85,7 @@ public class TimerRunner implements Runnable {
 					ProgSynthesis psProgSynthesis = new ProgSynthesis(contextId);
 					HashMap<String, String> unlabeledData = new HashMap<String, String>();
 					for (int i = 0; i < vtmp.size(); i++) {
-						unlabeledData.put("" + i, vtmp.get(i));
+						unlabeledData.put(String.valueOf(i), vtmp.get(i));
 					}
 					psProgSynthesis.inite(examples, dpp, msger);
 					Vector<ProgramRule> pls = new Vector<ProgramRule>();
@@ -129,8 +129,8 @@ public class TimerRunner implements Runnable {
 								String indicator = "wrong";
 								if (s.compareTo(entries.get(j)[1]) == 0)
 									indicator = "correct";
-								if (!uData.containsKey(j + ""))
-									uData.put(j + "", dict);
+								if (!uData.containsKey(String.valueOf(j)))
+									uData.put(String.valueOf(j), dict);
 							}
 							// classifier accuracy
 
@@ -157,7 +157,7 @@ public class TimerRunner implements Runnable {
 										"<_START>" + entries.get(j)[0]
 												+ "<_END>", "", tmps,
 										classlabel, "wrong" };
-								xHashMap.put(j + "", ts);
+								xHashMap.put(String.valueOf(j), ts);
 								wexam = ts;
 								checknumber++;
 							}
@@ -202,7 +202,7 @@ public class TimerRunner implements Runnable {
 									wexam = ts;
 									ts[4] = "wrong";
 								}
-								xHashMap.put(j + "", ts);
+								xHashMap.put(String.valueOf(j), ts);
 							}
 						}
 
@@ -234,9 +234,9 @@ public class TimerRunner implements Runnable {
 							int e = Integer.parseInt(expsel.Choose());
 							// /
 							System.out.println("Recommand Example: "
-									+ Arrays.toString(xHashMap.get("" + e)));
+									+ Arrays.toString(xHashMap.get(String.valueOf(e))));
 							// /
-							if (xHashMap.get("" + e)[4].compareTo("right") != 0) {
+							if (xHashMap.get(String.valueOf(e))[4].compareTo("right") != 0) {
 								wexp[0] = "<_START>" + entries.get(e)[0]
 										+ "<_END>";
 								wexp[1] = entries.get(e)[1];
@@ -245,7 +245,7 @@ public class TimerRunner implements Runnable {
 								// update positive training data
 								addExamples.add(entries.get(e));
 								// update the rest dataset
-								xHashMap.remove("" + e);
+								xHashMap.remove(String.valueOf(e));
 							}
 							checknumber++;
 						}

--- a/karma-typer/src/main/java/edu/isi/karma/semantictypes/typinghandler/HybridSTModelHandler.java
+++ b/karma-typer/src/main/java/edu/isi/karma/semantictypes/typinghandler/HybridSTModelHandler.java
@@ -470,15 +470,15 @@ public class HybridSTModelHandler implements ISemanticTypeModelHandler {
 		ArrayList<String> allowed = new ArrayList<String>();
 		// Adding A-Z
 		for (int c = 65; c <= 90; c++) {
-			allowed.add(new Character((char) c).toString());
+			allowed.add(String.valueOf((char) c));
 		}
 		// Adding a-z
 		for (int c = 97; c <= 122; c++) {
-			allowed.add(new Character((char) c).toString());
+			allowed.add(String.valueOf((char) c));
 		}
 		// Adding 0-9
 		for (int c = 48; c <= 57; c++) {
-			allowed.add(new Character((char) c).toString());
+			allowed.add(String.valueOf((char) c));
 		}
 		allowed.add(" "); // adding space
 		allowed.add("."); // adding dot

--- a/karma-typer/src/main/java/edu/isi/karma/semantictypes/typinghandler/LuceneBasedSTModelHandler.java
+++ b/karma-typer/src/main/java/edu/isi/karma/semantictypes/typinghandler/LuceneBasedSTModelHandler.java
@@ -320,15 +320,15 @@ public class LuceneBasedSTModelHandler implements ISemanticTypeModelHandler {
 		ArrayList<String> allowed = new ArrayList<String>();
 		// Adding A-Z
 		for (int c = 65; c <= 90; c++) {
-			allowed.add(new Character((char) c).toString());
+			allowed.add(String.valueOf((char) c));
 		}
 		// Adding a-z
 		for (int c = 97; c <= 122; c++) {
-			allowed.add(new Character((char) c).toString());
+			allowed.add(String.valueOf((char) c));
 		}
 		// Adding 0-9
 		for (int c = 48; c <= 57; c++) {
-			allowed.add(new Character((char) c).toString());
+			allowed.add(String.valueOf((char) c));
 		}
 		allowed.add(" "); // adding space
 		allowed.add("."); // adding dot


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.