### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AlignmentSVGVisualizationUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AlignmentSVGVisualizationUpdate.java
@@ -115,6 +115,14 @@ public class AlignmentSVGVisualizationUpdate extends AbstractUpdate {
 	}
 
 	@Override
+	public int hashCode() {
+		int result = this.worksheetId != null ? this.worksheetId.hashCode() : 0;
+		result = 31 * result + (this.alignmentGraph != null ? this.alignmentGraph.hashCode() : 0);
+		result = 31 * result + (this.alignment != null ? this.alignment.hashCode() : 0);
+		return result;
+	}
+
+	@Override
 	public void generateJson(String prefix, PrintWriter pw,
 			VWorkspace vWorkspace) {
 		Workspace workspace = vWorkspace.getWorkspace();

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AllWorksheetHeadersUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AllWorksheetHeadersUpdate.java
@@ -96,4 +96,10 @@ public class AllWorksheetHeadersUpdate extends AbstractUpdate {
 		return false;
 	}
 
+	@Override
+	public int hashCode() {
+		int result = this.worksheetId != null ? this.worksheetId.hashCode() : 0;
+		result = 31 * result + (this.deleteAfterGenerate ? 1 : 0);
+		return result;
+	}
 }

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/RegenerateWorksheetUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/RegenerateWorksheetUpdate.java
@@ -70,4 +70,8 @@ public class RegenerateWorksheetUpdate extends AbstractUpdate {
 		return false;
 	}
 
+	@Override
+	public int hashCode() {
+		return this.worksheetId != null ? this.worksheetId.hashCode() : 0;
+	}
 }

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetCleaningUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetCleaningUpdate.java
@@ -226,4 +226,12 @@ AbstractUpdate {
 		}
 		return false;
 	}
+
+	@Override
+	public int hashCode() {
+		int result = this.worksheetId != null ? this.worksheetId.hashCode() : 0;
+		result = 31 * result + (this.forceUpdates ? 1 : 0);
+		result = 31 * result + (this.selection != null ? this.selection.hashCode() : 0);
+		return result;
+	}
 }

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetDeleteUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetDeleteUpdate.java
@@ -52,5 +52,9 @@ public class WorksheetDeleteUpdate extends AbstractUpdate {
 		}
 		return false;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		return this.worksheetId != null ? this.worksheetId.hashCode() : 0;
+	}
 }

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetSuperSelectionListUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/WorksheetSuperSelectionListUpdate.java
@@ -52,4 +52,8 @@ public class WorksheetSuperSelectionListUpdate extends AbstractUpdate {
 		return false;
 	}
 
+	@Override
+	public int hashCode() {
+		return this.worksheetId != null ? this.worksheetId.hashCode() : 0;
+	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.