### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/DataPreProcessor.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/DataPreProcessor.java
@@ -5,7 +5,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.features.Feature;
@@ -85,9 +87,9 @@ public class DataPreProcessor {
 		return res;
 	}
 
-	public ArrayList<Integer> deCorrelate(HashMap<String, double[]> data) {
+	public ArrayList<Integer> deCorrelate(Map<String, double[]> data) {
 		ArrayList<Integer> toRemove = new ArrayList<Integer>();
-		HashSet<String> signs = new HashSet<String>();
+		Set<String> signs = new HashSet<String>();
 		// build singature for each feature
 		for (int i = 0; i < rfs.getFeatureNames().size(); i++) {
 			String sg = "";
@@ -127,7 +129,7 @@ public class DataPreProcessor {
 			Ruler r = new Ruler();
 			r.setNewInput(s1);
 			Vector<TNode> v = r.vec;
-			HashSet<String> curRow = new HashSet<String>();
+			Set<String> curRow = new HashSet<String>();
 			for (TNode t : v) {
 				String k = t.text;
 				k = k.replaceAll("[0-9]+", "DIGITs");

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleCluster.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleCluster.java
@@ -6,7 +6,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Vector;
 
 
@@ -15,7 +17,7 @@ import edu.isi.karma.cleaning.features.Feature;
 public class ExampleCluster {
 	public HashMap<String, Boolean> legalParitions = new HashMap<String, Boolean>();
 	Vector<Partition> examples = new Vector<Partition>();
-	HashSet<String> exampleInputs = new HashSet<String>();
+	Set<String> exampleInputs = new HashSet<String>();
 	Vector<Vector<String[]>> constraints = new Vector<Vector<String[]>>();
 	public ProgSynthesis pSynthesis; // data
 	HashMap<String, Vector<String>> uorgclusters = new HashMap<String, Vector<String>>();
@@ -67,11 +69,11 @@ public class ExampleCluster {
 	public void updateConstraints(Vector<Vector<String[]>> cnts) {
 		if (option == method.CPIC || option == method.DPIC
 				|| option == method.SPIC) {
-			HashMap<String, Vector<String[]>> xHashMap1 = new HashMap<String, Vector<String[]>>();
+			Map<String, Vector<String[]>> xHashMap1 = new HashMap<String, Vector<String[]>>();
 			for (Vector<String[]> group : cnts) {
 				xHashMap1.put(constraintKey(group), group);
 			}
-			HashSet<String> xHashSet2 = new HashSet<String>();
+			Set<String> xHashSet2 = new HashSet<String>();
 			for (Vector<String[]> group : constraints) {
 				xHashSet2.add(constraintKey(group));
 			}
@@ -82,7 +84,7 @@ public class ExampleCluster {
 			}
 			// update islegal ds
 			for (Vector<String[]> group : constraints) {
-				ArrayList<String> g = new ArrayList<String>();
+				List<String> g = new ArrayList<String>();
 				for (String[] p : group) {
 					String line = String.format("%s, %s\n", p[0], p[1]);
 					g.add(line);
@@ -311,7 +313,7 @@ public class ExampleCluster {
 		return pars;
 	}
 
-	public void assignUnlabeledData(Vector<Partition> pars) {
+	public void assignUnlabeledData(List<Partition> pars) {
 		HashMap<String, Double> dists = new HashMap<String, Double>();
 		// find the distance between partitions
 		for (int i = 0; i < pars.size(); i++) {
@@ -322,7 +324,7 @@ public class ExampleCluster {
 				}
 			}
 		}
-		HashMap<Partition, HashMap<String, Double>> testResult = new HashMap<Partition, HashMap<String, Double>>();
+		Map<Partition, HashMap<String, Double>> testResult = new HashMap<Partition, HashMap<String, Double>>();
 
 		for (String val : string2Vector.keySet()) {
 			Partition p_index = null;
@@ -402,7 +404,7 @@ public class ExampleCluster {
 	}
 
 	public ArrayList<ArrayList<Double>> convertStringSetToContrainMatrix(
-			ArrayList<String> strings) {
+			List<String> strings) {
 		ArrayList<ArrayList<Double>> res = new ArrayList<ArrayList<Double>>();
 		for (int i = 0; i < strings.size(); i++) {
 			for (int j = i + 1; j < strings.size(); j++) {
@@ -522,7 +524,7 @@ public class ExampleCluster {
 		return mindist;
 	}
 
-	public double getCompScore(Partition a, Partition b, Vector<Partition> pars) {
+	public double getCompScore(Partition a, Partition b, List<Partition> pars) {
 		String key = getStringKey(a, b);
 		for (String ekey : legalParitions.keySet()) {
 			if (key.indexOf(ekey) != -1 && !legalParitions.get(ekey)) {
@@ -605,7 +607,7 @@ public class ExampleCluster {
 			}
 		}
 		ProgramAdaptator pAdapter = new ProgramAdaptator(contextId);
-		ArrayList<Partition> nPs = new ArrayList<Partition>();
+		List<Partition> nPs = new ArrayList<Partition>();
 		nPs.add(p);
 		ArrayList<String[]> examps = UtilTools.extractExamplesinPartition(nPs);
 		String fprogram = pAdapter.adapt(pSynthesis.msGer.exp2Space,pSynthesis.msGer.exp2program, examps);
@@ -651,7 +653,7 @@ public class ExampleCluster {
 	}
 
 	public Vector<Partition> UpdatePartitions(int i, int j,
-			Vector<Partition> pars) {
+			List<Partition> pars) {
 		Partition p = pars.get(i).mergewith(pars.get(j));
 		Vector<Partition> res = new Vector<Partition>();
 		res.addAll(pars);
@@ -671,7 +673,7 @@ public class ExampleCluster {
 	// get a vector that can represent a partition
 	public double[] getPartitionVector(Partition p) {
 
-		ArrayList<double[]> vecs = new ArrayList<double[]>();
+		List<double[]> vecs = new ArrayList<double[]>();
 		for (Vector<TNode> orgs : p.orgNodes) {
 			vecs.add(string2Vector.get(UtilTools.print(orgs)));
 		}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
@@ -24,18 +24,24 @@ package edu.isi.karma.cleaning;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.QuestionableRecord.OutlierDetector;
 
 public class ExampleSelection {
-	public HashMap<String, Vector<TNode>> org = new HashMap<String, Vector<TNode>>();
-	public HashMap<String, Vector<TNode>> tran = new HashMap<String, Vector<TNode>>();
-	public HashMap<String, String[]> raw = new HashMap<String, String[]>();
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
+	public Map<String, Vector<TNode>> org = new HashMap<String, Vector<TNode>>();
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
+	public Map<String, Vector<TNode>> tran = new HashMap<String, Vector<TNode>>();
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
+	public Map<String, String[]> raw = new HashMap<String, String[]>();
 	public boolean isDetectingQuestionableRecord = false;
 	public OutlierDetector out;
 	// testdata rowid:{tar, tarcolor}
-	public HashMap<String, HashMap<String, String[]>> testdata = new HashMap<String, HashMap<String, String[]>>();
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
+	public Map<String, HashMap<String, String[]>> testdata = new HashMap<String, HashMap<String, String[]>>();
 	public int way = 7;
 	public HashSet<String> dictionary = new HashSet<String>();
 
@@ -88,8 +94,9 @@ public class ExampleSelection {
 
 	// exps: rowId: {org, tar, tarcode,classlabel}
 	// example: partition id: [{raw,tarcode}]
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
 	public void inite(HashMap<String, String[]> exps,
-			HashMap<String, Vector<String[]>> examples) {
+					  HashMap<String, Vector<String[]>> examples) {
 		// inite the class center vector
 
 		if (way >= 6) {
@@ -109,7 +116,7 @@ public class ExampleSelection {
 				String raw = exps.get(keyString)[0];
 				String[] pair = { raw, exps.get(keyString)[2] };
 				if (testdata.containsKey(exps.get(keyString)[3])) {
-					HashMap<String, String[]> xelem = testdata.get(exps
+					Map<String, String[]> xelem = testdata.get(exps
 							.get(keyString)[3]);
 					if (!xelem.containsKey(keyString)) {
 						xelem.put(keyString, pair);
@@ -167,8 +174,9 @@ public class ExampleSelection {
 		return ID;
 	}
 
-	public int ambiguityScore(Vector<TNode> vec) {
-		HashMap<String, Integer> d = new HashMap<String, Integer>();
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
+	public int ambiguityScore(List<TNode> vec) {
+		Map<String, Integer> d = new HashMap<String, Integer>();
 		int score = 0;
 		for (int i = 0; i < vec.size(); i++) {
 			if (d.containsKey(vec.get(i).text))
@@ -203,13 +211,14 @@ public class ExampleSelection {
 		return this.way2();
 	}
 
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
 	public String way6() {
 		int max = 2; // only the one with _FATAL_ERROR_ inside
 		if (firsttime) {
 			firsttime = false;
 			return this.way2();
 		}
-		Vector<String> examples = new Vector<String>();
+		List<String> examples = new Vector<String>();
 		for (String key : raw.keySet()) {
 			int cnt = 0;
 			String[] tmp = raw.get(key)[2]
@@ -252,6 +261,7 @@ public class ExampleSelection {
 		}
 	}
 
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
 	public String way7() {
 		// this.printdata();
 		int max = 2; // only the one with _FATAL_ERROR_ inside
@@ -259,7 +269,7 @@ public class ExampleSelection {
 			firsttime = false;
 			return this.way2();
 		}
-		Vector<String> examples = new Vector<String>();
+		List<String> examples = new Vector<String>();
 		for (String key : raw.keySet()) {
 			int cnt = 0;
 			String[] tmp = raw.get(key)[2]
@@ -361,11 +371,12 @@ public class ExampleSelection {
 		this.testdata.clear();
 	}
 
+	@SuppressWarnings("CollectionDeclaredAsConcreteClass")
 	public void printdata() {
 		String s1 = "";
 		String s2 = "";
 		for (String key : this.testdata.keySet()) {
-			HashMap<String, String[]> r = testdata.get(key);
+			Map<String, String[]> r = testdata.get(key);
 			s1 += "partition " + key + "\n";
 			for (String[] elem : r.values()) {
 				s1 += Arrays.toString(elem) + "\n";

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ANode.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ANode.java
@@ -21,6 +21,7 @@
 
 package edu.isi.karma.cleaning.Research;
 
+import java.util.List;
 import java.util.Vector;
 
 //used in alignment
@@ -29,7 +30,7 @@ public class ANode {
 	public Vector<Integer> tarPos = new Vector<Integer>();
 	public Vector<Integer> length = new Vector<Integer>();
 	public Vector<String[]> exps = new Vector<String[]>();
-	public Vector<ANode> children = new Vector<ANode>();
+	public List<ANode> children = new Vector<ANode>();
 
 	public ANode(Vector<Integer> orgPos, Vector<Integer> tarPos,
 			Vector<Integer> length, Vector<String[]> exps) {

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ClassifierRefiner.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ClassifierRefiner.java
@@ -3,6 +3,7 @@ package edu.isi.karma.cleaning.Research;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import edu.isi.karma.cleaning.Program;
 // input: classifier, results for each record
@@ -10,8 +11,8 @@ import edu.isi.karma.cleaning.Program;
 
 public class ClassifierRefiner {
 	Program prog;
-	HashMap<String, HashMap<String,String>> uData;
-	HashMap<String, ArrayList<String>> clusters = new HashMap<String, ArrayList<String>>();
+	Map<String, HashMap<String,String>> uData;
+	Map<String, ArrayList<String>> clusters = new HashMap<String, ArrayList<String>>();
 	public ClassifierRefiner(Program prog, HashMap<String, HashMap<String,String>> uData)
 	{
 		this.prog = prog;
@@ -28,7 +29,7 @@ public class ClassifierRefiner {
 	{
 		for(String row:uData.keySet())
 		{
-			HashMap<String, String> dict = uData.get(row);
+			Map<String, String> dict = uData.get(row);
 			String ckey = dict.get("class");
 			String org = dict.get("Org");
 			if(clusters.containsKey(ckey))

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ConstrainedAlignment.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/ConstrainedAlignment.java
@@ -1,5 +1,6 @@
 package edu.isi.karma.cleaning.Research;
 
+import java.util.List;
 import java.util.Vector;
 
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ public class ConstrainedAlignment {
 	// inserted same token
 	public void traverse() {
 		// inite
-		Vector<Integer> spos = new Vector<Integer>();
+		List<Integer> spos = new Vector<Integer>();
 		for (int i = 0; i < expnum; i++) {
 			spos.add(0);
 		}
@@ -46,7 +47,7 @@ class LatentState {
 	static final int ANC = 3;// a anchor state
 	public int StateType;
 	public LatentState nextState;
-	public Vector<int[]> segments;
+	public List<int[]> segments;
 
 	public LatentState(Vector<Integer> spos) {
 		this.StateType = LatentState.UND;

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/DataCollection.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/Research/DataCollection.java
@@ -26,14 +26,16 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.MyLogger;
 
 public class DataCollection {
 	public static String config = "";
-	Vector<FileStat> fstates = new Vector<FileStat>();
-	public HashSet<String> succeededFiles = new HashSet<String>();
+	List<FileStat> fstates = new Vector<FileStat>();
+	public Set<String> succeededFiles = new HashSet<String>();
 	@SuppressWarnings("unused")
 	public DataCollection() {
 		MyLogger myLogger = new MyLogger();

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/CntFeature.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/CntFeature.java
@@ -2,6 +2,7 @@ package edu.isi.karma.cleaning.features;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Vector;
 
 import edu.isi.karma.cleaning.Ruler;
@@ -23,8 +24,8 @@ public class CntFeature implements Feature {
 	}
 
 	// x is the old y is the new example
-	public double calFeatures(ArrayList<Vector<TNode>> x,
-			ArrayList<Vector<TNode>> y) {
+	public double calFeatures(List<Vector<TNode>> x,
+			List<Vector<TNode>> y) {
 		HashMap<Integer, Integer> tmp = new HashMap<Integer, Integer>();
 		for (int i = 0; i < y.size(); i++) {
 			int cnt = 0;

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
@@ -5,6 +5,8 @@ import java.io.FileWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import org.slf4j.Logger;
@@ -59,11 +61,11 @@ public class Data2Features {
 
 	// class: records convert them into csv file
 	public static void Traindata2CSV(
-			HashMap<String, Vector<String>> class2Records, String fpath,
+			Map<String, Vector<String>> class2Records, String fpath,
 			RecordFeatureSet rf) {
 		try {
 			CSVWriter writer = new CSVWriter(new FileWriter(new File(fpath)));
-			Vector<String> vsStrings = new Vector<String>();
+			List<String> vsStrings = new Vector<String>();
 			for (Vector<String> vecs : class2Records.values()) {
 				vsStrings.addAll(vecs);
 			}

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/history/CommandHistoryUtil.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/history/CommandHistoryUtil.java
@@ -28,7 +28,7 @@ public class CommandHistoryUtil {
 	private final List<Command> commands = new ArrayList<Command>();
 	private Workspace workspace;
 	private String worksheetId;
-	HashMap<String, CommandFactory> commandFactoryMap;
+	Map<String, CommandFactory> commandFactoryMap;
 	static Logger logger = Logger.getLogger(CommandHistoryUtil.class);
 
 	public CommandHistoryUtil(List<Command> commands, Workspace workspace, String worksheetId) {

--- a/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AlignmentSVGVisualizationUpdate.java
+++ b/karma-commands/commands-common/src/main/java/edu/isi/karma/controller/update/AlignmentSVGVisualizationUpdate.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.jgrapht.graph.DirectedWeightedMultigraph;
@@ -150,8 +151,8 @@ public class AlignmentSVGVisualizationUpdate extends AbstractUpdate {
 			JSONArray linksArr = new JSONArray();
 			JSONArray edgeLinksArr = new JSONArray();
 
-			HashMap<Node, Integer> verticesIndex = new HashMap<Node, Integer>();
-			HashMap<String, ColumnNode> columnNodes = new HashMap<>();
+			Map<Node, Integer> verticesIndex = new HashMap<Node, Integer>();
+			Map<String, ColumnNode> columnNodes = new HashMap<>();
 
 			if (alignmentGraph != null
 					&& alignmentGraph.vertexSet().size() != 0) {
@@ -330,7 +331,7 @@ public class AlignmentSVGVisualizationUpdate extends AbstractUpdate {
 			DisplayModel dm = new DisplayModel(alignmentGraph, vWorksheet
 					.getWorksheet().getHeaders());
 			HashMap<Node, Integer> nodeHeightsMap = dm.getNodesLevel();
-			HashMap<Node, Set<ColumnNode>> nodeCoverage = dm.getNodesSpan();
+			Map<Node, Set<ColumnNode>> nodeCoverage = dm.getNodesSpan();
 			/** Identify the max height **/
 			int maxTreeHeight = 0;
 			for (Node node : nodeHeightsMap.keySet()) {
@@ -346,7 +347,7 @@ public class AlignmentSVGVisualizationUpdate extends AbstractUpdate {
 					&& alignmentGraph.vertexSet().size() != 0) {
 				/** Add the nodes **/
 				Set<Node> nodes = alignmentGraph.vertexSet();
-				HashMap<Node, Integer> verticesIndex = new HashMap<Node, Integer>();
+				Map<Node, Integer> verticesIndex = new HashMap<Node, Integer>();
 				int nodesIndexcounter = 0;
 				for (Node node : nodes) {
 					/**

--- a/karma-commands/commands-import/import-database/src/main/java/edu/isi/karma/imp/database/DatabaseTableImport.java
+++ b/karma-commands/commands-import/import-database/src/main/java/edu/isi/karma/imp/database/DatabaseTableImport.java
@@ -96,7 +96,7 @@ public class DatabaseTableImport extends Import {
         return generateWorksheet(dbUtil, data);
     }
 
-    private Worksheet generateWorksheet(AbstractJDBCUtil dbUtil, ArrayList<ArrayList<String>> data)
+    private Worksheet generateWorksheet(AbstractJDBCUtil dbUtil, List<ArrayList<String>> data)
     {
 	    /**
 	     * Add the headers *
@@ -117,7 +117,7 @@ public class DatabaseTableImport extends Import {
 	    for (int i = 1; i < data.size(); i++)
 	    {
 		    Row row = dataTable.addRow(getFactory());
-		    ArrayList<String> rowData = data.get(i);
+		    List<String> rowData = data.get(i);
 		    for (int j = 0; j < rowData.size(); j++)
 		    {
 			    row.setValue(headersList.get(j), rowData.get(j), getFactory());

--- a/karma-commands/commands-update-jdbc/src/main/java/edu/isi/karma/controller/update/DatabaseTablePreviewUpdate.java
+++ b/karma-commands/commands-update-jdbc/src/main/java/edu/isi/karma/controller/update/DatabaseTablePreviewUpdate.java
@@ -23,6 +23,7 @@ package edu.isi.karma.controller.update;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -69,7 +70,7 @@ public class DatabaseTablePreviewUpdate extends AbstractUpdate {
 		try {
 			AbstractJDBCUtil dbUtil = JDBCUtilFactory.getInstance(dbType);
 			
-			ArrayList<ArrayList<String>> data = dbUtil.getDataForLimitedRows(dbType, hostname, 
+			List<ArrayList<String>> data = dbUtil.getDataForLimitedRows(dbType, hostname, 
 					portnumber, username, password, tableName, dBorSIDName, 10);
 			
 			JSONStringer jsonStr = new JSONStringer();

--- a/karma-commands/commands-update/src/main/java/edu/isi/karma/controller/update/AdditionalRowsUpdate.java
+++ b/karma-commands/commands-update/src/main/java/edu/isi/karma/controller/update/AdditionalRowsUpdate.java
@@ -72,7 +72,7 @@ public class AdditionalRowsUpdate extends AbstractUpdate {
 			JSONArray rowsJson = new JSONArray();
 			if(additionalRows.size()  > 0) {
 				Row row = additionalRows.get(0);
-				ArrayList<VHNode> nodeList = getNestedNodeList(row, vWorksheet.getHeaderViewNodes());
+				List<VHNode> nodeList = getNestedNodeList(row, vWorksheet.getHeaderViewNodes());
 				rowsJson = upd.getRowsJsonArray(additionalRows, vWorksheet, 
 							nodeList,
 							vWorkspace.getPreferences().getIntViewPreferenceValue(

--- a/karma-common/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
+++ b/karma-common/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
@@ -71,7 +71,7 @@ public class CommandHistory {
 
 	private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
-	private static HashMap<String, IHistorySaver> historySavers = new HashMap<>();
+	private static Map<String, IHistorySaver> historySavers = new HashMap<>();
 
 	private final static Set<CommandConsolidator> consolidators = new HashSet<>();
 
@@ -198,7 +198,7 @@ public class CommandHistory {
 
 	private void writeHistoryPerWorksheet(Workspace workspace, IHistorySaver historySaver) throws Exception {
 		String workspaceId = workspace.getId();
-		HashMap<String, JSONArray> comMap = new HashMap<String, JSONArray>();
+		Map<String, JSONArray> comMap = new HashMap<String, JSONArray>();
 		for(ICommand command : _getHistory()) {
 			if(command.isSavedInHistory() &&
 					(command.hasTag(CommandTag.Modeling)

--- a/karma-common/src/main/java/edu/isi/karma/imp/csv/CSVFileExport.java
+++ b/karma-common/src/main/java/edu/isi/karma/imp/csv/CSVFileExport.java
@@ -31,6 +31,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +65,7 @@ public class CSVFileExport {
 				filename;
 		logger.info("CSV file exported. Location:"
 				+ outputFile);
-		HashMap<String, String> modeledColumnTable = new HashMap<String, String>();
+		Map<String, String> modeledColumnTable = new HashMap<String, String>();
 		for (SemanticType type : worksheet.getSemanticTypes().getListOfTypes()) {
 			modeledColumnTable.put(type.getHNodeId(),"");
 		}

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/planning/DFSTriplesMapGraphDAGifier.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/planning/DFSTriplesMapGraphDAGifier.java
@@ -69,7 +69,7 @@ public class DFSTriplesMapGraphDAGifier implements TriplesMapGraphDAGifier {
 		return spilledNodes;
 	}
 
-	private List<String> cleanGraph(HashSet<String> triplesMapsIds,
+	private List<String> cleanGraph(Set<String> triplesMapsIds,
 			TriplesMapGraph newGraph, String rootTriplesMapId) {
 		boolean modifications = true;
 		List<String> spilledTriplesMaps = new LinkedList<String>();

--- a/karma-common/src/main/java/edu/isi/karma/kr2rml/writer/AvroKR2RMLRDFWriter.java
+++ b/karma-common/src/main/java/edu/isi/karma/kr2rml/writer/AvroKR2RMLRDFWriter.java
@@ -297,7 +297,7 @@ public class AvroKR2RMLRDFWriter extends SFKR2RMLRDFWriter<GenericRecord> {
 	
 	@Override
 	public void finishRow() {
-		for(ConcurrentHashMap<String, GenericRecord> records : this.rootObjectsByTriplesMapId.values())
+		for(Map<String, GenericRecord> records : this.rootObjectsByTriplesMapId.values())
 		{
 			
 			for(GenericRecord record : records.values()){ 

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/Alignment.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/Alignment.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.jgrapht.UndirectedGraph;
@@ -713,7 +714,7 @@ public class Alignment implements OntologyUpdateListener {
 					steinerNodes.add(n);
 				
 				if (n.getSemanticTypeStatus() == ColumnSemanticTypeStatus.UserAssigned) {
-					HashMap<SemanticType, LabeledLink> domainLinks = 
+					Map<SemanticType, LabeledLink> domainLinks = 
 							GraphUtil.getDomainLinks(this.graphBuilder.getGraph(), n, n.getUserSemanticTypes());
 					if (domainLinks != null) {
 						for (LabeledLink l : domainLinks.values()) {
@@ -745,7 +746,7 @@ public class Alignment implements OntologyUpdateListener {
 			}
 		}
 		
-		ArrayList<Node> result = new ArrayList<>();
+		List<Node> result = new ArrayList<>();
 		result.addAll(steinerNodes);
 		return result;
 	}
@@ -1042,7 +1043,7 @@ public class Alignment implements OntologyUpdateListener {
 		DirectedWeightedMultigraph<Node, LabeledLink> tree = 
 				new DirectedWeightedMultigraph<Node, LabeledLink>(LabeledLink.class);
 
-		HashMap<Node, Node> modelToAlignmentNode = new HashMap<Node, Node>();
+		Map<Node, Node> modelToAlignmentNode = new HashMap<Node, Node>();
 		for (Node n : model.getGraph().vertexSet()) {
 			if (n instanceof InternalNode) {
 

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/AlignmentManager.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/AlignmentManager.java
@@ -21,6 +21,8 @@
 package edu.isi.karma.modeling.alignment;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import edu.isi.karma.modeling.ontology.OntologyManager;
@@ -28,7 +30,7 @@ import edu.isi.karma.rep.Worksheet;
 import edu.isi.karma.rep.WorkspaceManager;
 
 public class AlignmentManager {
-	private static ConcurrentHashMap<String, Alignment> alignmentMap = null;
+	private static Map<String, Alignment> alignmentMap = null;
 	private static AlignmentManager _InternalInstance = null;
 	public static AlignmentManager Instance()
 	{
@@ -79,7 +81,7 @@ public class AlignmentManager {
 	}
 
 	public void removeWorkspaceAlignments(String workspaceId) {
-		ArrayList<String> keysToBeRemoved = new ArrayList<String>();
+		List<String> keysToBeRemoved = new ArrayList<String>();
 		for(String key:alignmentMap.keySet()) {
 			if(key.startsWith(workspaceId+":")) {
 				keysToBeRemoved.add(key);

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/BANKSfromMM_Old.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/BANKSfromMM_Old.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.Set;
 import java.util.TreeSet;
 
 //import org.slf4j.Logger;
@@ -24,7 +25,7 @@ public class BANKSfromMM_Old extends TopKSteinertrees {
 
 	private int iteratorCounter=0;
 	
-	private HashMap<SteinerNode,SteinerNode> recurseNodeMap;
+	private Map<SteinerNode,SteinerNode> recurseNodeMap;
 	private List<HashMap<SteinerNode,SteinerNode>> shortestNodeIndex;
 	private List<HashMap<SteinerNode,SortedSteinerNodes>> duplicateIndex;
 	private String contextId;
@@ -37,7 +38,7 @@ public class BANKSfromMM_Old extends TopKSteinertrees {
 	}
 	
 	class SortedSteinerNodes{
-		TreeSet<SteinerNode> set;
+		Set<SteinerNode> set;
 		SortedSteinerNodes(){
 			set= new TreeSet<SteinerNode>(new Comparator<SteinerNode>(){
 				public int compare(SteinerNode n1, SteinerNode n2){
@@ -189,7 +190,7 @@ public class BANKSfromMM_Old extends TopKSteinertrees {
 	 */
 	private void getApprTree(
 			SteinerNode ancestor, 
-			HashMap<Integer, SteinerNode> searchNodeInQueues, 
+			Map<Integer, SteinerNode> searchNodeInQueues, 
 			List<Map<String, SteinerNode>> processedNodes, 
 			int queueId) throws Exception{
 		TreeSet<SteinerNode> steinerNodes = new TreeSet<SteinerNode>();

--- a/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/CustomizedBANKS.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/steiner/topk/CustomizedBANKS.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.Set;
 import java.util.TreeSet;
 
 import edu.isi.karma.config.ModelingConfiguration;
@@ -24,7 +25,7 @@ public class CustomizedBANKS extends TopKSteinertrees {
 	private int iteratorCounter=0;
 	private ModelCoherence modelCoherence;
 	
-	private HashMap<SteinerNode,SteinerNode> recurseNodeMap;
+	private Map<SteinerNode,SteinerNode> recurseNodeMap;
 	private List<HashMap<SteinerNode,SteinerNode>> shortestNodeIndex;
 	private List<HashMap<SteinerNode,SortedSteinerNodes>> duplicateIndex;
 	private String contextId;
@@ -37,7 +38,7 @@ public class CustomizedBANKS extends TopKSteinertrees {
 	}
 	
 	class SortedSteinerNodes{
-		TreeSet<SteinerNode> set;
+		Set<SteinerNode> set;
 		SortedSteinerNodes(){
 			set= new TreeSet<SteinerNode>(new Comparator<SteinerNode>(){
 				public int compare(SteinerNode n1, SteinerNode n2){
@@ -199,7 +200,7 @@ public class CustomizedBANKS extends TopKSteinertrees {
 	 */
 	private void getApprTree(
 			SteinerNode ancestor, 
-			HashMap<Integer, SteinerNode> searchNodeInQueues, 
+			Map<Integer, SteinerNode> searchNodeInQueues, 
 			List<Map<String, SteinerNode>> processedNodes, 
 			int queueId) throws Exception{
 		TreeSet<SteinerNode> steinerNodes = new TreeSet<SteinerNode>();

--- a/karma-common/src/main/java/edu/isi/karma/rep/alignment/DisplayModel.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/alignment/DisplayModel.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
@@ -106,7 +107,7 @@ public class DisplayModel {
 		
 		//Remove missing Levels
 		int newMaxLevel = getMaxLevel(false);
-		HashMap<Integer, Set<Node>> nodesAtLevel = getLevelToNodes(null, false);
+		Map<Integer, Set<Node>> nodesAtLevel = getLevelToNodes(null, false);
 		for(int i=maxLevel; i<newMaxLevel; i++) {
 			Set<Node> nodes = nodesAtLevel.get(i);
 			if(nodes == null || nodes.size() == 0) {
@@ -285,7 +286,7 @@ public class DisplayModel {
 			}
 		}
 		
-		HashMap<Integer, Set<Node>> levelToNodes = getLevelToNodes(model, false);
+		Map<Integer, Set<Node>> levelToNodes = getLevelToNodes(model, false);
 		
 		// find in/out degree in each level
 		int k = 0;
@@ -418,7 +419,7 @@ public class DisplayModel {
 			nodesSpan.put(n, columnNodes);
 		}
 		
-		HashMap<Integer, Set<Node>> levelToNodes = getLevelToNodes(model, true);
+		Map<Integer, Set<Node>> levelToNodes = getLevelToNodes(model, true);
 		Set<ColumnNode> allColumnNodes = new HashSet<ColumnNode>();
 		
 		int i = getMaxLevel(true);
@@ -496,7 +497,7 @@ public class DisplayModel {
 		List<Integer> n1SpanPositions = new ArrayList<Integer>();
 		List<Integer> n2SpanPositions = new ArrayList<Integer>();
 		
-		ArrayList<HNode> orderedNodeIds = new ArrayList<HNode>();
+		List<HNode> orderedNodeIds = new ArrayList<HNode>();
 		this.hTable.getSortedLeafHNodes(orderedNodeIds);
 		if (orderedNodeIds != null)
 		for (int i = 0; i < orderedNodeIds.size(); i++) {
@@ -548,7 +549,7 @@ public class DisplayModel {
 		
 		int maxLevel = model.vertexSet().size();
 
-		HashMap<Integer, Set<Node>> levelToNodes = getLevelToNodes(model, false);
+		Map<Integer, Set<Node>> levelToNodes = getLevelToNodes(model, false);
 
 		// find in/out degree in each level
 		int k = 0;

--- a/karma-common/src/main/java/edu/isi/karma/rep/sources/DataSource.java
+++ b/karma-common/src/main/java/edu/isi/karma/rep/sources/DataSource.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.jgrapht.graph.DirectedWeightedMultigraph;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class DataSource extends Source {
 	private Model model;
 	private List<String> variables;
 
-	HashMap<String, Attribute> attIdToAttMap;
+	Map<String, Attribute> attIdToAttMap;
 
 	public DataSource(String id) {
 		super(id);
@@ -129,7 +130,7 @@ public class DataSource extends Source {
 		
 		Model m = new Model("model");
 		
-		HashMap<String, Argument> vertexIdToArgument = new HashMap<String, Argument>();
+		Map<String, Argument> vertexIdToArgument = new HashMap<String, Argument>();
 		List<Attribute> attributeList = new ArrayList<Attribute>();
 		
 		// get the column name associated to the hNodeIds to assign to attribute names 

--- a/karma-jdbc/src/main/java/edu/isi/karma/rdf/DatabaseTableRDFGenerator.java
+++ b/karma-jdbc/src/main/java/edu/isi/karma/rdf/DatabaseTableRDFGenerator.java
@@ -172,7 +172,7 @@ public class DatabaseTableRDFGenerator extends RdfGenerator {
 		
 		int counter = 0;
 		
-		ArrayList<String> rowValues = null;
+		List<String> rowValues = null;
 		while ((rowValues = dbUtil.parseResultSetRow(r)) != null) {
 			// Generate RDF and create a new worksheet for every DATABASE_TABLE_FETCH_SIZE rows
 			if(counter%DATABASE_TABLE_FETCH_SIZE == 0 && counter != 0) {
@@ -233,7 +233,7 @@ public class DatabaseTableRDFGenerator extends RdfGenerator {
 	private List<String> addHeaders (Worksheet wk, List<String> columnNames,
 			RepFactory factory) {
 		HTable headers = wk.getHeaders();
-		ArrayList<String> headersList = new ArrayList<String>();
+		List<String> headersList = new ArrayList<String>();
         for(int i=0; i< columnNames.size(); i++){
         	HNode hNode = null;
         	hNode = headers.addHNode(columnNames.get(i), HNodeType.Regular, wk, factory);

--- a/karma-jdbc/src/main/java/edu/isi/karma/util/AbstractJDBCUtil.java
+++ b/karma-jdbc/src/main/java/edu/isi/karma/util/AbstractJDBCUtil.java
@@ -207,7 +207,7 @@ public abstract class AbstractJDBCUtil {
 	 * @throws ClassNotFoundException
 	 */
 	public boolean tableExists(String tableName, Connection conn) throws SQLException, ClassNotFoundException {
-		ArrayList<String> tn = getListOfTables(conn);
+		List<String> tn = getListOfTables(conn);
 
 		if (tn.contains(tableName)) {
 			return true;

--- a/karma-mr/src/main/java/edu/isi/karma/mapreduce/function/CreateSequenceFile.java
+++ b/karma-mr/src/main/java/edu/isi/karma/mapreduce/function/CreateSequenceFile.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -37,7 +38,7 @@ import edu.isi.karma.rdf.CommandLineArgumentParser;
 
 public class CreateSequenceFile {
 
-	ConcurrentHashMap<String, SequenceFile.Writer> writers = new ConcurrentHashMap<String, SequenceFile.Writer>();
+	Map<String, Writer> writers = new ConcurrentHashMap<String, SequenceFile.Writer>();
 	boolean useKey = true;
 	boolean outputFileName = false;
 	String filePath = null;

--- a/karma-offline/src/main/java/edu/isi/karma/rdf/BaseRDFImpl.java
+++ b/karma-offline/src/main/java/edu/isi/karma/rdf/BaseRDFImpl.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,7 +37,7 @@ public abstract class BaseRDFImpl implements Serializable {
     protected boolean hasHeader = false;
     boolean readKarmaConfig = false;
     protected JSONArray jKarmaConfig = null;
-    protected HashMap<String, Pattern> urlPatterns=null;
+    protected Map<String, Pattern> urlPatterns=null;
     protected boolean disableNesting = false;
     public BaseRDFImpl(String propertyPath) {
         try {

--- a/karma-typer/src/main/java/edu/isi/karma/semantictypes/evaluation/EvaluateMRR.java
+++ b/karma-typer/src/main/java/edu/isi/karma/semantictypes/evaluation/EvaluateMRR.java
@@ -16,6 +16,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -59,7 +60,7 @@ public class EvaluateMRR {
 
 					// Reading correct Semantic labels and storing in an array list 
 					JSONArray userArray = (JSONArray) obj.get("userSemanticTypes");
-					ArrayList <String> correctTypes= new ArrayList<String>();
+					List<String> correctTypes= new ArrayList<String>();
 					for(Object o1: userArray){
 						JSONObject userObj= (JSONObject) o1;
 						correctTypes.add(userObj.get("domain").toString() + userObj.get("type").toString());
@@ -67,7 +68,7 @@ public class EvaluateMRR {
 
 					// Reading learned Semantic labels and storing in an array list 
 					JSONArray learnedArray = (JSONArray) obj.get("learnedSemanticTypes");
-					ArrayList <String> learnedTypes= new ArrayList<String>();
+					List<String> learnedTypes= new ArrayList<String>();
 					if (learnedArray != null)
 					for(Object o2: learnedArray){
 						JSONObject learnedObj= (JSONObject) o2;
@@ -162,7 +163,7 @@ public class EvaluateMRR {
 
 					// Reading correct Semantic labels and storing in an array list 
 					JSONArray userArray = (JSONArray) obj.get("userSemanticTypes");
-					ArrayList <String> correctTypes= new ArrayList<String>();
+					List<String> correctTypes= new ArrayList<String>();
 					for(Object o1: userArray){
 						JSONObject userObj= (JSONObject) o1;
 						correctTypes.add(userObj.get("domain").toString() + userObj.get("type").toString());
@@ -170,7 +171,7 @@ public class EvaluateMRR {
 
 					// Reading learned Semantic labels and storing in an array list 
 					JSONArray learnedArray = (JSONArray) obj.get("learnedSemanticTypes");
-					ArrayList <String> learnedTypes= new ArrayList<String>();
+					List<String> learnedTypes= new ArrayList<String>();
 					for(Object o2: learnedArray){
 						JSONObject learnedObj= (JSONObject) o2;
 						learnedTypes.add(learnedObj.get("domain").toString() + learnedObj.get("type").toString()); 

--- a/karma-util/src/main/java/edu/isi/karma/webserver/ContextParametersRegistry.java
+++ b/karma-util/src/main/java/edu/isi/karma/webserver/ContextParametersRegistry.java
@@ -1,12 +1,13 @@
 package edu.isi.karma.webserver;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 
 public class ContextParametersRegistry {
 	private static ContextParametersRegistry singleton = new ContextParametersRegistry();
 
-	private final ConcurrentHashMap<String, ServletContextParameterMap> karmaHomeToContextParameters = new ConcurrentHashMap<String, ServletContextParameterMap>();
+	private final Map<String, ServletContextParameterMap> karmaHomeToContextParameters = new ConcurrentHashMap<String, ServletContextParameterMap>();
 
 	public static ContextParametersRegistry getInstance() {
 		return singleton;

--- a/karma-web-services/web-services-publish-es/src/main/java/edu/isi/karma/web/services/publish/es/ElasticSearchPublishServlet.java
+++ b/karma-web-services/web-services-publish-es/src/main/java/edu/isi/karma/web/services/publish/es/ElasticSearchPublishServlet.java
@@ -12,6 +12,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
@@ -338,7 +339,7 @@ public class ElasticSearchPublishServlet extends Application {
 	public static void initContextParameters(ServletContext ctx, ServletContextParameterMap contextParameters)
 	{
 		Enumeration<?> params = ctx.getInitParameterNames();
-		ArrayList<String> validParams = new ArrayList<String>();
+		List<String> validParams = new ArrayList<String>();
 		for (ContextParameter param : ContextParameter.values()) {
 			validParams.add(param.name());
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.