### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/DataPreProcessor.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/DataPreProcessor.java
@@ -28,7 +28,7 @@ public class DataPreProcessor {
 		return data2Vector;
 	}
 	public void run() {
-		Vector<String> toks = buildDict(data);
+		ArrayList<String> toks = buildDict(data);
 		// vectorize String
 		String[] vocb = toks.toArray(new String[toks.size()]);
 		rfs.addVocabulary(vocb);
@@ -114,7 +114,7 @@ public class DataPreProcessor {
 		return res;
 	}
 
-	public static Vector<String> buildDict(Collection<String> data) {
+	public static ArrayList<String> buildDict(Collection<String> data) {
 		HashMap<String, Integer> mapHashSet = new HashMap<String, Integer>();
 		for (String pair : data) {
 			String s1 = pair;
@@ -162,7 +162,7 @@ public class DataPreProcessor {
 				iter.remove();
 			}
 		}
-		Vector<String> res = new Vector<String>();
+		ArrayList<String> res = new ArrayList<String>();
 		res.addAll(mapHashSet.keySet());
 		return res;
 	}

--- a/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleTraces.java
+++ b/karma-cleaning/src/main/java/edu/isi/karma/cleaning/ExampleTraces.java
@@ -2,6 +2,7 @@ package edu.isi.karma.cleaning;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Vector;
 /*
  *store the traces for all the examples
@@ -39,14 +40,14 @@ public class ExampleTraces {
 		String key = String.format("%s|%s", example[0],example[1]);
 		return expTraces.get(key);
 	}
-	public Vector<Vector<Segment>> getCurrentSegments(String[] example)
+	public ArrayList<ArrayList<Segment>> getCurrentSegments(String[] example)
 	{
-		Vector<Vector<Segment>> res = new Vector<Vector<Segment>>();
+		ArrayList<ArrayList<Segment>> res = new ArrayList<ArrayList<Segment>>();
 		Traces t = this.getTrace(example);
 		Collection<Template> x = t.traceline.values();
 		for(Template tmp:x)
 		{
-			Vector<Segment> line = new Vector<Segment>();
+			ArrayList<Segment> line = new ArrayList<Segment>();
 			for(GrammarTreeNode node:tmp.body)
 			{
 				line.add((Segment)node);
@@ -66,7 +67,7 @@ public class ExampleTraces {
 			return s.tarString;
 		}
 	}
-	public Vector<int[]> getSegmentPos(Segment s)
+	public ArrayList<int[]> getSegmentPos(Segment s)
 	{
 		if(s.isConstSegment())
 		{
@@ -74,7 +75,7 @@ public class ExampleTraces {
 		}
 		else
 		{
-			Vector<int[]> poses = new Vector<int[]>();
+			ArrayList<int[]> poses = new ArrayList<int[]>();
 			for(Section sec:s.section)
 			{
 				int[] x = {sec.pair[0].absPosition.get(0),sec.pair[1].absPosition.get(0)};


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.