### PR TITLE
Converting Karma to use rdfs:label fields for class naming when they are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.history
 *.iml
 atlassian-ide-plugin.xml
 java_pid*.hprof

--- a/karma-commands/commands-alignment/src/main/java/edu/isi/karma/controller/command/alignment/GetClassesCommand.java
+++ b/karma-commands/commands-alignment/src/main/java/edu/isi/karma/controller/command/alignment/GetClassesCommand.java
@@ -129,7 +129,13 @@ public class GetClassesCommand extends WorksheetCommand {
 						String nodeLabelStr = node.getDisplayId();
 
 						Label nodeLabel = node.getLabel();
-						if (nodeLabel.getUri() !=null && nodeLabel.getNs() != null 
+						// ~~~
+						// UPDATED 07-05-16 -  provide rdfs:label names when they are used.
+						if( nodeLabel.getRdfsLabel() != null ) {
+							nodeLabelStr = nodeLabel.getRdfsLabel();						
+						}
+	 					// ~~~
+						else if (nodeLabel.getUri() != null && nodeLabel.getNs() != null 
 								&& nodeLabel.getUri().equalsIgnoreCase(nodeLabel.getNs())) {
 							nodeLabelStr = node.getId();
 						} else if(nodeLabel.getPrefix() == null && nodeLabel.getUri() != null) {

--- a/karma-commands/commands-alignment/src/main/java/edu/isi/karma/controller/command/alignment/GetCurrentLinksOfInternalNodeCommand.java
+++ b/karma-commands/commands-alignment/src/main/java/edu/isi/karma/controller/command/alignment/GetCurrentLinksOfInternalNodeCommand.java
@@ -144,15 +144,28 @@ public class GetCurrentLinksOfInternalNodeCommand extends Command {
 				String edgeTargetUri = edgeTarget.getUri();
 				
 				Label srcNodeLabel = edgeSource.getLabel();
-				if (srcNodeLabel.getUri() !=null && srcNodeLabel.getNs() != null 
+				// ~~~
+				// UPDATED 07-05-16 -  provide rdfs:label names when they are used.
+				if ( srcNodeLabel.getRdfsLabel() != null ) {
+					edgeSourceLabel = srcNodeLabel.getRdfsLabel();
+				} 
+				// ~~~
+				else if (srcNodeLabel.getUri() !=null && srcNodeLabel.getNs() != null 
 						&& srcNodeLabel.getUri().equalsIgnoreCase(srcNodeLabel.getNs())) {
 					edgeSourceLabel = edgeSource.getId();
 				}
 				Label trgNodeLabel = edgeTarget.getLabel();
-				if (trgNodeLabel.getUri() !=null && trgNodeLabel.getNs() != null 
+				// ~~~
+				// UPDATED 07-05-16 -  provide rdfs:label names when they are used.
+				if ( trgNodeLabel.getRdfsLabel() != null ) {
+					edgeTargetLabel = trgNodeLabel.getRdfsLabel();
+				} 
+				// ~~~
+				else if (trgNodeLabel.getUri() !=null && trgNodeLabel.getNs() != null 
 						&& trgNodeLabel.getUri().equalsIgnoreCase(trgNodeLabel.getNs())) {
 					edgeTargetLabel = edgeTarget.getId();
 				}
+				// ~~~
 					
 				JSONObject edgeObj = new JSONObject();
 				edgeObj.put(JsonKeys.edgeId.name(), link.getLabel().getUri());

--- a/karma-commands/commands-alignment/src/main/java/edu/isi/karma/controller/command/alignment/GetPropertiesCommand.java
+++ b/karma-commands/commands-alignment/src/main/java/edu/isi/karma/controller/command/alignment/GetPropertiesCommand.java
@@ -169,7 +169,12 @@ public class GetPropertiesCommand extends WorksheetCommand {
 							edgeLabelStr = linkLabel.getUri();
 						}
 						
-						edgeObj.put(JsonKeys.label.name(), edgeLabelStr);
+						// UPDATED 07-05-16 -  provide rdfs:label names when they are used.
+						if( linkLabel.getRdfsLabel() == null )
+							edgeObj.put(JsonKeys.label.name(), edgeLabelStr);
+						else 
+							edgeObj.put(JsonKeys.label.name(), linkLabel.getRdfsLabel());
+							
 						edgeObj.put(JsonKeys.uri.name(), linkLabel.getUri());
 						edgeObj.put(JsonKeys.id.name(), link.getId());
 						

--- a/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/modeling/alignment/GraphUtil.java
@@ -654,7 +654,7 @@ public class GraphUtil {
 		writer.name("uri").value(label.getUri());
 //		writer.name("ns").value(label.getNs());
 //		writer.name("prefix").value(label.getPrefix());
-//		writer.name("rdfsLabel").value(label.getRdfsLabel());
+		writer.name("rdfsLabel").value(label.getRdfsLabel());
 //		writer.name("rdfsComment").value(label.getRdfsComment());
 		writer.endObject();
 	}
@@ -915,21 +915,21 @@ public class GraphUtil {
 //		String ns = null;
 //		String prefix = null;
 //		String rdfsComment = null;
-//		String rdfsLabel = null;
+		String rdfsLabel = null;
 		
 		reader.beginObject();
 	    while (reader.hasNext()) {
 	    	String key = reader.nextName();
 			if (key.equals("uri") && reader.peek() != JsonToken.NULL) {
 				uri = reader.nextString();
-//			} else if (key.equals("ns") && reader.peek() != JsonToken.NULL) {
-//				ns = reader.nextString();
-//			} else if (key.equals("prefix") && reader.peek() != JsonToken.NULL) {
-//				prefix = reader.nextString();
-//			} else if (key.equals("rdfsLabel") && reader.peek() != JsonToken.NULL) {
-//				rdfsLabel = reader.nextString();
-//			} else if (key.equals("rdfsComment") && reader.peek() != JsonToken.NULL) {
-//				rdfsComment = reader.nextString();
+			//} else if (key.equals("ns") && reader.peek() != JsonToken.NULL) {
+			//	ns = reader.nextString();
+			//} else if (key.equals("prefix") && reader.peek() != JsonToken.NULL) {
+			//	prefix = reader.nextString();
+			//} else if (key.equals("rdfsLabel") && reader.peek() != JsonToken.NULL) {
+			//	rdfsLabel = reader.nextString();
+			//} else if (key.equals("rdfsComment") && reader.peek() != JsonToken.NULL) {
+			//	rdfsComment = reader.nextString();
 			} else {
 			  reader.skipValue();
 			}


### PR DESCRIPTION
I made changes in server-side commands (when I could trace them) to change the returned JSON sent to the client to the RDFS:label data. In fact, the edu.isi.karma.rep.alignment.Label class contains the desired data already, loaded from the owl file but different commands load their data in different ways. 

Of concern is how the nodes are built in the client as instances (usually by simply adding an integer to the end of the class name). Maybe, we should continue this so as not to break the existing implementation but add an extra field to the returned JSON where needed. 

Changes made were annotated with 'UPDATED 07-05-16' 