### PR TITLE
Update maven repository

### DIFF
--- a/vagrant/basebox-create.sh
+++ b/vagrant/basebox-create.sh
@@ -6,10 +6,10 @@ sudo yum -y groupinstall 'Development Tools'
 sudo yum -y install wget
 
 cd /tmp
-sudo wget http://apache-mirror.rbc.ru/pub/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
-sudo tar -xvzpf apache-maven-3.3.3-bin.tar.gz
-sudo mv apache-maven-3.3.3 /usr/local/
-sudo ln -s /usr/local/apache-maven-3.3.3/bin/* /usr/local/bin/
+sudo wget http://www-eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+sudo tar -xvzpf apache-maven-3.3.9-bin.tar.gz
+sudo mv apache-maven-3.3.9 /usr/local/
+sudo ln -s /usr/local/apache-maven-3.3.9/bin/* /usr/local/bin/
 
 cd /home/vagrant/
 git clone https://github.com/usc-isi-i2/Web-Karma.git


### PR DESCRIPTION
When the basebox-create.sh tries to download maven from the repository at http://apache-mirror.rbc.ru/pub/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz, the client receives a 404 response.

For this reason, I have updated the repository url with the following one: http://www-eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz.