### PR TITLE
Allow users to specify model uri and context from UI when publishing models

### DIFF
--- a/karma-commands/commands-alignment-openrdf/src/main/java/edu/isi/karma/kr2rml/KR2RMLMappingWriter.java
+++ b/karma-commands/commands-alignment-openrdf/src/main/java/edu/isi/karma/kr2rml/KR2RMLMappingWriter.java
@@ -79,10 +79,16 @@ public class KR2RMLMappingWriter {
 		initializeURIs();
 	}
 
-	private Resource addKR2RMLMappingResource(Worksheet worksheet, KR2RMLMapping mapping)
+	private Resource addKR2RMLMappingResource(Worksheet worksheet, KR2RMLMapping mapping, String optionalMappingUri)
 			throws RepositoryException {
 		/** Create resource for the mapping as a blank node **/
-		Resource mappingRes = f.createBNode();
+		Resource mappingRes;
+		if(optionalMappingUri != null) {
+			mappingRes = f.createURI(optionalMappingUri);
+		}
+		else {
+			mappingRes = f.createBNode();
+		}
 		con.add(mappingRes, RDF.TYPE, repoURIs.get(Uris.KM_R2RML_MAPPING_URI));
 		Value srcNameVal = f.createLiteral(worksheet.getTitle());
 		con.add(mappingRes, repoURIs.get(Uris.KM_SOURCE_NAME_URI), srcNameVal);
@@ -135,10 +141,15 @@ public class KR2RMLMappingWriter {
 
 	public boolean addR2RMLMapping(KR2RMLMapping mapping, Worksheet worksheet, Workspace workspace)
 			throws RepositoryException, JSONException {
+		return addR2RMLMapping(mapping, worksheet, workspace, null);
+	}
+	
+	public boolean addR2RMLMapping(KR2RMLMapping mapping, Worksheet worksheet, Workspace workspace, String optionalMappingUri)
+			throws RepositoryException, JSONException {
 
 		try {
 
-			Resource mappingRes = addKR2RMLMappingResource(worksheet, mapping);
+			Resource mappingRes = addKR2RMLMappingResource(worksheet, mapping, optionalMappingUri);
 			addTripleMaps(mapping, mappingRes, worksheet, workspace);
 			addPrefixes(mapping);
 			

--- a/karma-commands/commands-alignment-openrdf/src/main/java/edu/isi/karma/kr2rml/KR2RMLMappingWriter.java
+++ b/karma-commands/commands-alignment-openrdf/src/main/java/edu/isi/karma/kr2rml/KR2RMLMappingWriter.java
@@ -83,7 +83,7 @@ public class KR2RMLMappingWriter {
 			throws RepositoryException {
 		/** Create resource for the mapping as a blank node **/
 		Resource mappingRes;
-		if(optionalMappingUri != null) {
+		if(optionalMappingUri != null && !optionalMappingUri.trim().isEmpty()) {
 			mappingRes = f.createURI(optionalMappingUri);
 		}
 		else {

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/GenerateR2RMLModelCommand.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/GenerateR2RMLModelCommand.java
@@ -77,6 +77,8 @@ public class GenerateR2RMLModelCommand extends WorksheetSelectionCommand {
 
 	private String worksheetName;
 	private String tripleStoreUrl;
+	private String graphUri;
+	private String modelUri;
 	private String RESTserverAddress;
 	private static Logger logger = LoggerFactory.getLogger(GenerateR2RMLModelCommand.class);
 
@@ -88,9 +90,11 @@ public class GenerateR2RMLModelCommand extends WorksheetSelectionCommand {
 		rdfPrefix, rdfNamespace, modelSparqlEndPoint
 	}
 
-	protected GenerateR2RMLModelCommand(String id, String model, String worksheetId, String url, String selectionId) {
+	protected GenerateR2RMLModelCommand(String id, String model, String worksheetId, String url, String selectionId, String graphUri, String modelUri) {
 		super(id, model, worksheetId, selectionId);
 		this.tripleStoreUrl = url;
+		this.graphUri = graphUri;
+		this.modelUri = modelUri;
 	}
 
 	public String getTripleStoreUrl() {
@@ -337,21 +341,21 @@ public class GenerateR2RMLModelCommand extends WorksheetSelectionCommand {
 		try {
 			R2RMLAlignmentFileSaver fileSaver = new R2RMLAlignmentFileSaver(workspace);
 
-			fileSaver.saveAlignment(alignment, modelFileLocalPath);
+			fileSaver.saveAlignment(alignment, null, modelFileLocalPath, false, modelUri);
 
 			// Write the model to the triple store
 
-			// Get the graph name from properties
-			String graphName = worksheet.getMetadataContainer().getWorksheetProperties()
-					.getPropertyValue(Property.graphName);
-			if (graphName == null || graphName.isEmpty()) {
-				// Set to default
-				worksheet.getMetadataContainer().getWorksheetProperties().setPropertyValue(
-						Property.graphName, WorksheetProperties.createDefaultGraphName(worksheet.getTitle()));
-				worksheet.getMetadataContainer().getWorksheetProperties().setPropertyValue(
-						Property.graphLabel, worksheet.getTitle());
-				graphName = WorksheetProperties.createDefaultGraphName(worksheet.getTitle());
-			}
+//			// Get the graph name from properties
+//			String graphName = worksheet.getMetadataContainer().getWorksheetProperties()
+//					.getPropertyValue(Property.graphName);
+//			if (graphName == null || graphName.isEmpty()) {
+//				// Set to default
+//				worksheet.getMetadataContainer().getWorksheetProperties().setPropertyValue(
+//						Property.graphName, WorksheetProperties.createDefaultGraphName(worksheet.getTitle()));
+//				worksheet.getMetadataContainer().getWorksheetProperties().setPropertyValue(
+//						Property.graphLabel, worksheet.getTitle());
+//				graphName = WorksheetProperties.createDefaultGraphName(worksheet.getTitle());
+//			}
 
 			boolean result = true;//utilObj.saveToStore(modelFileLocalPath, tripleStoreUrl, graphName, true, null);
 			if (tripleStoreUrl != null && tripleStoreUrl.trim().compareTo("") != 0) {
@@ -359,11 +363,11 @@ public class GenerateR2RMLModelCommand extends WorksheetSelectionCommand {
 					UriBuilder builder = UriBuilder.fromPath(modelFileName);
 					String url = RESTserverAddress + "/R2RMLMapping/local/" + builder.build().toString();
 					SaveR2RMLModelCommandFactory factory = new SaveR2RMLModelCommandFactory();
-					SaveR2RMLModelCommand cmd = factory.createCommand(model, workspace, url, tripleStoreUrl, graphName, "URL");
+					SaveR2RMLModelCommand cmd = factory.createCommand(model, workspace, url, tripleStoreUrl, graphUri, "URL");
 					cmd.doIt(workspace);
 					result &= cmd.getSuccessful();
 					workspace.getWorksheet(worksheetId).getMetadataContainer().getWorksheetProperties().setPropertyValue(Property.modelUrl, url);
-					workspace.getWorksheet(worksheetId).getMetadataContainer().getWorksheetProperties().setPropertyValue(Property.modelContext, graphName);
+					workspace.getWorksheet(worksheetId).getMetadataContainer().getWorksheetProperties().setPropertyValue(Property.modelContext, graphUri);
 					workspace.getWorksheet(worksheetId).getMetadataContainer().getWorksheetProperties().setPropertyValue(Property.modelRepository, tripleStoreUrl);
 				} catch(Exception e) {
 					logger.error("Error pushing model to triple store", e);

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/GenerateR2RMLModelCommandFactory.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/GenerateR2RMLModelCommandFactory.java
@@ -34,7 +34,7 @@ public class GenerateR2RMLModelCommandFactory extends CommandFactory {
 	private enum Arguments {
 		worksheetId, addInverseProperties, rdfPrefix, 
 		rdfNamespace, tripleStoreUrl, graphContext, 
-		localTripleStoreUrl, selectionName
+		localTripleStoreUrl, selectionName, graphUri, modelUri
 	}
 
 	@Override
@@ -43,15 +43,21 @@ public class GenerateR2RMLModelCommandFactory extends CommandFactory {
 		String tripleStoreUrl = request.getParameter(Arguments.tripleStoreUrl.name());
 		String RESTserverAddress = request.getRequestURL().substring(0, request.getRequestURL().lastIndexOf("/RequestController"));
 		String selectionName = request.getParameter(Arguments.selectionName.name());
+		String graphUri = request.getParameter(Arguments.graphUri.name());
+		String modelUri = request.getParameter(Arguments.modelUri.name());
 		GenerateR2RMLModelCommand cmd = new GenerateR2RMLModelCommand(getNewId(workspace), 
 				Command.NEW_MODEL, worksheetId, tripleStoreUrl, 
-				selectionName);
+				selectionName, graphUri, modelUri);
 		cmd.setRESTserverAddress(RESTserverAddress);
 		return cmd;
 	}
 	
-	public Command createCommand(String model, Workspace workspace, String worksheetId, String tripleStoreUrl,  String selectionId) {
-		return new GenerateR2RMLModelCommand(getNewId(workspace), model, worksheetId, tripleStoreUrl, selectionId);
+	public Command createCommand(String model, Workspace workspace, String worksheetId, String tripleStoreUrl,  String selectionId, String graphUri, String modelUri) {
+		return new GenerateR2RMLModelCommand(getNewId(workspace), model, worksheetId, tripleStoreUrl, selectionId, graphUri, modelUri);
+	}
+
+	public Command createCommand(String model, Workspace workspace, String worksheetId, String tripleStoreUrl,  String selectionId, String graphUri) {
+		return new GenerateR2RMLModelCommand(getNewId(workspace), model, worksheetId, tripleStoreUrl, selectionId, graphUri, null);
 	}
 
 	@Override

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/R2RMLAlignmentFileSaver.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/R2RMLAlignmentFileSaver.java
@@ -68,18 +68,23 @@ public class R2RMLAlignmentFileSaver implements IAlignmentSaver, IHistorySaver {
 	
 	@Override
 	public void saveAlignment(Alignment alignment) throws Exception {
-		saveAlignment(alignment, null, null, false);
+		saveAlignment(alignment, null, null, false, null);
 	}
 	
 	public void saveAlignment(Alignment alignment, JSONArray history)  throws Exception {
-		saveAlignment(alignment, history, null, false);
+		saveAlignment(alignment, history, null, false, null);
 	}
 	
 	public void saveAlignment(Alignment alignment, String modelFilename)  throws Exception {
-		saveAlignment(alignment, null, modelFilename, false);
+		saveAlignment(alignment, null, modelFilename, false, null);
 	}
 	
 	public void saveAlignment(Alignment alignment, JSONArray history, String modelFilename, boolean onlyHistory) throws Exception {
+		saveAlignment(alignment, history, modelFilename, onlyHistory, null);
+		
+	}
+
+	public void saveAlignment(Alignment alignment, JSONArray history, String modelFilename, boolean onlyHistory, String optionalMappingUri) throws Exception {
 		long start = System.currentTimeMillis();
 		
 		String workspaceId = AlignmentManager.Instance().getWorkspaceId(alignment);
@@ -104,8 +109,8 @@ public class R2RMLAlignmentFileSaver implements IAlignmentSaver, IHistorySaver {
 		
 		// Write the model
 		if (modelFilename != null && !modelFilename.trim().isEmpty())
-			writeModel(workspace, workspace.getOntologyManager(), alignmentMappingGenerator, worksheet, modelFilename);
-		logger.info("Alignment for " + workspaceId + ":" + worksheetId + " saved to file: " + modelFilename);
+			writeModel(workspace, workspace.getOntologyManager(), alignmentMappingGenerator, worksheet, modelFilename, optionalMappingUri);
+		logger.info("Alignment for " + workspaceId + ":" + worksheetId + " saved to file: " + modelFilename + " with optional mapping uir: " + optionalMappingUri);
 		long end3 = System.currentTimeMillis();
 		logger.info("Time to write to file:" + (end3-end2) + "msec");
 	}
@@ -115,7 +120,7 @@ public class R2RMLAlignmentFileSaver implements IAlignmentSaver, IHistorySaver {
 	}
 	
 	private void writeModel(Workspace workspace, OntologyManager ontMgr, 
-			KR2RMLMappingGenerator mappingGen, Worksheet worksheet, String modelFileLocalPath) 
+			KR2RMLMappingGenerator mappingGen, Worksheet worksheet, String modelFileLocalPath, String optionalMappingUri) 
 					throws RepositoryException, FileNotFoundException,
 							UnsupportedEncodingException, JSONException {
 		File f = new File(modelFileLocalPath);
@@ -124,7 +129,7 @@ public class R2RMLAlignmentFileSaver implements IAlignmentSaver, IHistorySaver {
 		PrintWriter writer = new PrintWriter(f, "UTF-8");
 
 		KR2RMLMappingWriter mappingWriter = new KR2RMLMappingWriter();
-		mappingWriter.addR2RMLMapping(mappingGen.getKR2RMLMapping(), worksheet, workspace);
+		mappingWriter.addR2RMLMapping(mappingGen.getKR2RMLMapping(), worksheet, workspace, optionalMappingUri);
 		mappingWriter.writeR2RMLMapping(writer);
 		mappingWriter.close();
 		writer.flush();

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/R2RMLAlignmentFileSaver.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/alignment/R2RMLAlignmentFileSaver.java
@@ -110,7 +110,7 @@ public class R2RMLAlignmentFileSaver implements IAlignmentSaver, IHistorySaver {
 		// Write the model
 		if (modelFilename != null && !modelFilename.trim().isEmpty())
 			writeModel(workspace, workspace.getOntologyManager(), alignmentMappingGenerator, worksheet, modelFilename, optionalMappingUri);
-		logger.info("Alignment for " + workspaceId + ":" + worksheetId + " saved to file: " + modelFilename + " with optional mapping uir: " + optionalMappingUri);
+		logger.info("Alignment for " + workspaceId + ":" + worksheetId + " saved to file: " + modelFilename + " with optional mapping uri: " + optionalMappingUri);
 		long end3 = System.currentTimeMillis();
 		logger.info("Time to write to file:" + (end3-end2) + "msec");
 	}

--- a/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/worksheet/FetchColumnCommand.java
+++ b/karma-commands/commands-publish-alignment-openrdf/src/main/java/edu/isi/karma/controller/command/worksheet/FetchColumnCommand.java
@@ -120,7 +120,7 @@ public class FetchColumnCommand extends WorksheetSelectionCommand {
 			// If the model is not published, publish it!
 			if(!f.exists() || !f.isFile()) {
 				GenerateR2RMLModelCommandFactory factory = new GenerateR2RMLModelCommandFactory();
-				GenerateR2RMLModelCommand cmd = (GenerateR2RMLModelCommand)factory.createCommand(model, workspace, worksheetId, TripleStoreUtil.defaultModelsRepoUrl, selection.getName());
+				GenerateR2RMLModelCommand cmd = (GenerateR2RMLModelCommand)factory.createCommand(model, workspace, worksheetId, TripleStoreUtil.defaultModelsRepoUrl, selection.getName(), graphName);
 				cmd.doIt(workspace);
 			} else {
 				// if the model was published 30 min ago, publish it again, just to be sure
@@ -128,7 +128,7 @@ public class FetchColumnCommand extends WorksheetSelectionCommand {
 				if((diff / 1000L / 60L) > 30) {
 					f.delete();
 					GenerateR2RMLModelCommandFactory factory = new GenerateR2RMLModelCommandFactory();
-					GenerateR2RMLModelCommand cmd = (GenerateR2RMLModelCommand)factory.createCommand(model, workspace, worksheetId, TripleStoreUtil.defaultModelsRepoUrl, selection.getName());
+					GenerateR2RMLModelCommand cmd = (GenerateR2RMLModelCommand)factory.createCommand(model, workspace, worksheetId, TripleStoreUtil.defaultModelsRepoUrl, selection.getName(), graphName);
 					cmd.doIt(workspace);
 				}
 			}

--- a/karma-common/src/main/java/edu/isi/karma/er/helper/TripleStoreUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/er/helper/TripleStoreUtil.java
@@ -542,7 +542,7 @@ public class TripleStoreUtil {
 		injectType(mappingURI, query, Uris.RR_TEMPLATE_URI, Uris.RR_CLASS_URI, Uris.KM_HAS_SUBJECT_MAP_URI);
 		query.append("{\n");
 		query.append("?s ?p ?o .\n");
-		query.append("?s owl:sameAs ");
+		query.append("?s (owl:sameAs|^owl:sameAs)* ");
 		formatURI(mappingURI, query);
 		query.append(" . \n"); 
 
@@ -559,7 +559,7 @@ public class TripleStoreUtil {
 		query.append("?mapping <");
 		query.append(hasType);
 		query.append("> ?s . \n");
-		query.append("?mapping owl:sameAs ");
+		query.append("?mapping (owl:sameAs|^owl:sameAs)* ");
 		formatURI(mappingURI, query);
 		query.append(" .\n");
 		query.append("?s ?p ?o . \n");
@@ -579,7 +579,7 @@ public class TripleStoreUtil {
 		query.append("?mapping <");
 		query.append(hasType2);
 		query.append("> ?mapping2 . \n");
-		query.append("?mapping owl:sameAs ");
+		query.append("?mapping (owl:sameAs|^owl:sameAs)* ");
 		formatURI(mappingURI, query);
 		query.append(" .\n");
 		query.append("?s ?p ?o . \n");

--- a/karma-common/src/main/java/edu/isi/karma/er/helper/TripleStoreUtil.java
+++ b/karma-common/src/main/java/edu/isi/karma/er/helper/TripleStoreUtil.java
@@ -857,7 +857,7 @@ public class TripleStoreUtil {
 
 			StringBuilder query = new StringBuilder();
 			query.append("PREFIX km-dev:<http://isi.edu/integration/karma/dev#>\n");
-			query.append("SELECT ?z ?y ?x ?src ?w ?u\n");
+			query.append("SELECT ?z ?y ?x ?src ?w ?u ?a\n");
 			injectContext(context, query);
 			query.append("WHERE \n { \n");
 			query.append("GRAPH ?src \n { \n");
@@ -888,7 +888,13 @@ public class TripleStoreUtil {
 				while (count < values.length()) {
 					JSONObject o = values.getJSONObject(count++);
 					times.add(o.getJSONObject("x").getString("value"));
-					urls.add(o.getJSONObject("z").getString("value"));
+					if(o.getJSONObject("a").getString("type").equalsIgnoreCase("bnode")){
+						urls.add(o.getJSONObject("z").getString("value"));
+					}
+					else {
+						urls.add(o.getJSONObject("a").getString("value"));
+					}
+						
 					if (o.has("w"))
 							inputColumns.add(o.getJSONObject("w").getString("value"));
 					else

--- a/karma-web/src/main/webapp/index.jsp
+++ b/karma-web/src/main/webapp/index.jsp
@@ -364,6 +364,8 @@ and related projects, please see: http://www.isi.edu/integration
         <script type="text/javascript" src="js/initWS.js?<jsp:include page='version.jsp' />"></script>
         <script type="text/javascript" src="js/commandHistory.js?<jsp:include page='version.jsp' />"></script>
         <script type="text/javascript" src="js/publishRDF.js?<jsp:include page='version.jsp' />"></script>
+        <script type="text/javascript" src="js/publishHelper.js?<jsp:include page='version.jsp' />"></script>
+        <script type="text/javascript" src="js/publishModel.js?<jsp:include page='version.jsp' />"></script>
         <script type="text/javascript" src="js/serviceImport.js?<jsp:include page='version.jsp' />"></script>
         <script type="text/javascript" src="js/pager.js?<jsp:include page='version.jsp' />"></script>
         <script type="text/javascript" src="js/geospatial.js?<jsp:include page='version.jsp' />"></script>

--- a/karma-web/src/main/webapp/js/publishHelper.js
+++ b/karma-web/src/main/webapp/js/publishHelper.js
@@ -2,10 +2,12 @@ var PublishHelper = (function() {
 	var instance = null;
 
 	function PrivateConstructor() {
+		var worksheetId; 
+		
 		function init() {
 			
 		}
-		function fetchGraphsFromTripleStore(url, rdfOrModel) {
+		function fetchGraphsFromTripleStore(url, rdfOrModel, dialog) {
 
 			var info = generateInfoObject("", "", "FetchGraphsFromTripleStoreCommand");
 			info["tripleStoreUrl"] = url;
@@ -38,6 +40,7 @@ var PublishHelper = (function() {
 
 					graphList.unbind('change');
 					graphList.change(function(event) {
+						hideError(dialog);
 						if ($('#'+rdfOrModel+'GraphList').val() == "create_new_context") {
 							$('#'+rdfOrModel+'SPAQRLGraph').val(getUniqueGraphUri(null, url, rdfOrModel));
 							$('#labelFor_'+rdfOrModel+'SPAQRLGraph').show();
@@ -55,7 +58,18 @@ var PublishHelper = (function() {
 			});
 		}
 
-		function validate(url, rdfOrModel) {
+		function hideError(dialog) {
+			$("div.error", dialog).hide();
+		}
+		
+		function showError(dialog, err) {
+			$("div.error", dialog).show();
+			if (err) {
+				$("div.error", dialog).text(err);
+			}
+		}
+		
+		function validate(url, rdfOrModel, dialog) {
 			var expression = /(^|\s)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/gi;
 			// /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
 			var regex = new RegExp(expression);
@@ -85,8 +99,9 @@ var PublishHelper = (function() {
 				}
 				var newUri = getUniqueGraphUri(graphUri, url, rdfOrModel);
 				if (graphUri != newUri) {
-					showError("The context you provided already exists. Please either enter a different context name, " +
+					showError(dialog, "The context you provided already exists. Please either enter a different context name, " +
 						"or select the context from the 'Use existing context' dropdown");
+					return;
 				}
 			}
 			return graphUri
@@ -140,14 +155,20 @@ var PublishHelper = (function() {
 			return String($('#'+rdfOrModel+'SPAQRLGraph').attr('rel'));
 		}
 
+		function show(wsId) {
+			worksheetId = wsId;
+		};
+
 		return { //Return back the public methods
 			fetchGraphsFromTripleStore: fetchGraphsFromTripleStore,
 			init: init,
+			show: show,
 			validate: validate,
 			getGraphURIForWorksheet: getGraphURIForWorksheet
 		};
 	};
 
+	
 	function getInstance() {
 		if (!instance) {
 			instance = new PrivateConstructor();

--- a/karma-web/src/main/webapp/js/publishHelper.js
+++ b/karma-web/src/main/webapp/js/publishHelper.js
@@ -92,7 +92,7 @@ var PublishHelper = (function() {
 			return graphUri
 		}
 
-		function getGraphURIForWorksheet(rdfForGraph) {
+		function getGraphURIForWorksheet(rdfOrModel) {
 			// get the graph uri for the worksheet
 			var info = generateInfoObject(worksheetId, "", "FetchExistingWorksheetPropertiesCommand");
 
@@ -107,22 +107,22 @@ var PublishHelper = (function() {
 
 					// Set graph name
 					if (props["graphName"] != null) {
-						$("#"+rdfForGraph+"SPAQRLGraph").val(props["graphName"]);
+						$("#"+rdfOrModel+"SPAQRLGraph").val(props["graphName"]);
 					} else {
-						$("#"+rdfForGraph+"SPAQRLGraph").val("");
+						$("#"+rdfOrModel+"SPAQRLGraph").val("");
 					}
 				}
 			});
-			return $("#"+rdfForGraph+"SPAQRLGraph").val();
+			return $("#"+rdfOrModel+"SPAQRLGraph").val();
 		}
 
-		function getUniqueGraphUri(graphUriTobeValidated, tripleStoreURL, rdfForGraph) {
+		function getUniqueGraphUri(graphUriTobeValidated, tripleStoreURL, rdfOrModel) {
 			var info = generateInfoObject(worksheetId, "", "GetUniqueGraphUrlCommand");
 			info["tripleStoreUrl"] = tripleStoreURL;
 			if (graphUriTobeValidated && graphUriTobeValidated != null) {
 				info["graphUri"] = graphUriTobeValidated;
 			}
-			$('#'+rdfForGraph+'SPAQRLGraph').attr('rel', '');
+			$('#'+rdfOrModel+'SPAQRLGraph').attr('rel', '');
 			var returned = $.ajax({
 				url: "RequestController",
 				type: "POST",
@@ -131,13 +131,13 @@ var PublishHelper = (function() {
 				async: false,
 				complete: function(xhr, textStatus) {
 					var json = $.parseJSON(xhr.responseText);
-					$('#rdfSPAQRLGraph').attr('rel', json.elements[0].graphUri);
+					$('#'+rdfOrModel+'SPAQRLGraph').attr('rel', json.elements[0].graphUri);
 				},
 				error: function(xhr, textStatus) {
 					alert("Error occurred with fetching graphs! " + textStatus);
 				}
 			});
-			return String($('#rdfSPAQRLGraph').attr('rel'));
+			return String($('#'+rdfOrModel+'SPAQRLGraph').attr('rel'));
 		}
 
 		return { //Return back the public methods

--- a/karma-web/src/main/webapp/js/publishHelper.js
+++ b/karma-web/src/main/webapp/js/publishHelper.js
@@ -1,0 +1,163 @@
+var PublishHelper = (function() {
+	var instance = null;
+
+	function PrivateConstructor() {
+		function init() {
+			
+		}
+		function fetchGraphsFromTripleStore(url, rdfOrModel) {
+
+			var info = generateInfoObject("", "", "FetchGraphsFromTripleStoreCommand");
+			info["tripleStoreUrl"] = url;
+			var returned = $.ajax({
+				url: "RequestController",
+				type: "POST",
+				data: info,
+				dataType: "json",
+				complete: function(xhr, textStatus) {
+					var json = $.parseJSON(xhr.responseText);
+					graphs = [];
+					if (json["elements"] && json["elements"][0]['graphs']) {
+						graphs = json["elements"][0]['graphs'];
+					}
+					var graphList = $("#"+rdfOrModel+"GraphList");
+					graphList.html('<option value="create_new_context">Create New Context </option>');
+					for (var x in graphs) {
+						graphList.append('<option value="' + graphs[x] + '">' + graphs[x] + '</option>');
+					}
+					if (graphs.length > 0) {
+						graphList.val(graphs[0]);
+						$('#labelFor_'+rdfOrModel+'SPAQRLGraph').hide();
+						$('#'+rdfOrModel+'SPAQRLGraph').hide();
+					} else {
+						graphList.val("create_new_context");
+						$('#'+rdfOrModel+'SPAQRLGraph').val(getUniqueGraphUri(null, url, rdfOrModel));
+						$('#labelFor_'+rdfOrModel+'SPAQRLGraph').show();
+						$('#'+rdfOrModel+'SPAQRLGraph').show();
+					}
+
+					graphList.unbind('change');
+					graphList.change(function(event) {
+						if ($('#'+rdfOrModel+'GraphList').val() == "create_new_context") {
+							$('#'+rdfOrModel+'SPAQRLGraph').val(getUniqueGraphUri(null, url, rdfOrModel));
+							$('#labelFor_'+rdfOrModel+'SPAQRLGraph').show();
+							$('#'+rdfOrModel+'SPAQRLGraph').show();
+						} else {
+							$('#labelFor_'+rdfOrModel+'SPAQRLGraph').hide();
+							$('#'+rdfOrModel+'SPAQRLGraph').hide();
+						}
+						//$('#rdfSPAQRLGraph').val($('#modelGraphList').val());
+					});
+				},
+				error: function(xhr, textStatus) {
+					alert("Error occurred with fetching graphs! " + textStatus);
+				}
+			});
+		}
+
+		function validate(url, rdfOrModel) {
+			var expression = /(^|\s)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/gi;
+			// /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
+			var regex = new RegExp(expression);
+			var graphUri = "";
+			var needsValidation = false;
+			if ($('#'+rdfOrModel+'GraphList').val() == "create_new_context") {
+				graphUri = $("input#"+rdfOrModel+"SPAQRLGraph").val();
+				needsValidation = true;
+			} else {
+				graphUri = $('#'+rdfOrModel+'GraphList').val();
+			}
+			// validate the sparql endpoint
+			if (!testSparqlEndPoint(url, worksheetId)) {
+				alert("Invalid sparql end point. Could not establish connection.");
+				return;
+			}
+
+			// validate the graph uri
+			if (needsValidation) {
+				if (graphUri.length < 3) {
+					alert("Context field is empty");
+					return;
+				}
+				if (!graphUri.match(regex)) {
+					alert("Invalid Url format for context");
+					return;
+				}
+				var newUri = getUniqueGraphUri(graphUri, url, rdfOrModel);
+				if (graphUri != newUri) {
+					showError("The context you provided already exists. Please either enter a different context name, " +
+						"or select the context from the 'Use existing context' dropdown");
+				}
+			}
+			return graphUri
+		}
+
+		function getGraphURIForWorksheet(rdfForGraph) {
+			// get the graph uri for the worksheet
+			var info = generateInfoObject(worksheetId, "", "FetchExistingWorksheetPropertiesCommand");
+
+			var returned = $.ajax({
+				url: "RequestController",
+				type: "POST",
+				data: info,
+				dataType: "json",
+				complete: function(xhr, textStatus) {
+					var json = $.parseJSON(xhr.responseText);
+					var props = json["elements"][0]["properties"];
+
+					// Set graph name
+					if (props["graphName"] != null) {
+						$("#"+rdfForGraph+"SPAQRLGraph").val(props["graphName"]);
+					} else {
+						$("#"+rdfForGraph+"SPAQRLGraph").val("");
+					}
+				}
+			});
+			return $("#"+rdfForGraph+"SPAQRLGraph").val();
+		}
+
+		function getUniqueGraphUri(graphUriTobeValidated, tripleStoreURL, rdfForGraph) {
+			var info = generateInfoObject(worksheetId, "", "GetUniqueGraphUrlCommand");
+			info["tripleStoreUrl"] = tripleStoreURL;
+			if (graphUriTobeValidated && graphUriTobeValidated != null) {
+				info["graphUri"] = graphUriTobeValidated;
+			}
+			$('#'+rdfForGraph+'SPAQRLGraph').attr('rel', '');
+			var returned = $.ajax({
+				url: "RequestController",
+				type: "POST",
+				data: info,
+				dataType: "json",
+				async: false,
+				complete: function(xhr, textStatus) {
+					var json = $.parseJSON(xhr.responseText);
+					$('#rdfSPAQRLGraph').attr('rel', json.elements[0].graphUri);
+				},
+				error: function(xhr, textStatus) {
+					alert("Error occurred with fetching graphs! " + textStatus);
+				}
+			});
+			return String($('#rdfSPAQRLGraph').attr('rel'));
+		}
+
+		return { //Return back the public methods
+			fetchGraphsFromTripleStore: fetchGraphsFromTripleStore,
+			init: init,
+			validate: validate,
+			getGraphURIForWorksheet: getGraphURIForWorksheet
+		};
+	};
+
+	function getInstance() {
+		if (!instance) {
+			instance = new PrivateConstructor();
+			instance.init();
+		}
+		return instance;
+	}
+
+	return {
+		getInstance: getInstance
+	};
+
+})();

--- a/karma-web/src/main/webapp/js/publishModel.js
+++ b/karma-web/src/main/webapp/js/publishModel.js
@@ -38,14 +38,17 @@ var PublishModelDialog = (function() {
 				}
 				window.rdfSPAQRLEndPoint = $('#txtModel_URL').html();
 				helper.getGraphURIForWorksheet('model');
-				helper.fetchGraphsFromTripleStore($('#txtModel_URL').html(), 'model');
+				helper.fetchGraphsFromTripleStore($('#txtModel_URL').html(), 'model', dialog);
 			});
 
 			//Initialize handler for Save button
 			//var me = this;
 			$('#btnSave', dialog).on('click', function(e) {
 				e.preventDefault();
-				graphURI = helper.validate($('#txtModel_URL').html(), 'model');
+				graphURI = helper.validate($('#txtModel_URL').html(), 'model', dialog);
+				if (! graphURI) {
+					return
+				}
 				publishModelFunction(graphURI)
 			});
 
@@ -153,20 +156,13 @@ var PublishModelDialog = (function() {
 			$("div.error", dialog).hide();
 		}
 
-		function showError(err) {
-			$("div.error", dialog).show();
-			if (err) {
-				$("div.error", dialog).text(err);
-			}
-		}
-
-
 		function hide() {
 			dialog.modal('hide');
 		}
 
 		function show(wsId) {
 			worksheetId = wsId;
+			helper.show(worksheetId)
 			dialog.modal({
 				keyboard: true,
 				show: true,

--- a/karma-web/src/main/webapp/js/publishModel.js
+++ b/karma-web/src/main/webapp/js/publishModel.js
@@ -51,6 +51,20 @@ var PublishModelDialog = (function() {
 
 		}
 
+		function publishToGithub(worksheetId, repo) {
+			var auth = Settings.getInstance().getGithubAuth();
+			if(repo != "disabled" && !repo.endsWith("disabled)")) {
+				if(auth) {
+					showLoading(worksheetId);
+					var githubInfo = generateInfoObject(worksheetId, "", "PublishGithubCommand");
+			        githubInfo["worksheetId"] = worksheetId;
+			        githubInfo["auth"] = auth;
+			        githubInfo["repo"] = repo;
+			        var returned = sendRequest(githubInfo, worksheetId);
+			    }
+		    }
+		}
+		
         function publishModelFunction(graphUri) {
 			hide();
 			var info = generateInfoObject(worksheetId, "", "GenerateR2RMLModelCommand");

--- a/karma-web/src/main/webapp/js/publishRDF.js
+++ b/karma-web/src/main/webapp/js/publishRDF.js
@@ -42,14 +42,17 @@ var PublishRDFDialog = (function() {
 				getRDFPreferences();
 				window.rdfSPAQRLEndPoint = $('#txtData_URL').html();
 				helper.getGraphURIForWorksheet('rdf');
-				helper.fetchGraphsFromTripleStore($('#txtData_URL').html(), 'rdf');
+				helper.fetchGraphsFromTripleStore($('#txtData_URL').html(), 'rdf', dialog);
 			});
 
 			//Initialize handler for Save button
 			//var me = this;
 			$('#btnSave', dialog).on('click', function(e) {
 				e.preventDefault();
-				graphURI = helper.validate($('#txtData_URL').html(), 'rdf');
+				graphURI = helper.validate($('#txtData_URL').html(), 'rdf', dialog);
+				if (! graphURI) {
+					return
+				}
 				publishRDFFunction(graphURI);
 			});
 
@@ -147,20 +150,13 @@ var PublishRDFDialog = (function() {
 			$("div.error", dialog).hide();
 		}
 
-		function showError(err) {
-			$("div.error", dialog).show();
-			if (err) {
-				$("div.error", dialog).text(err);
-			}
-		}
-
-
 		function hide() {
 			dialog.modal('hide');
 		}
 
 		function show(wsId) {
 			worksheetId = wsId;
+			helper.show(worksheetId)
 			dialog.modal({
 				keyboard: true,
 				show: true,

--- a/karma-web/src/main/webapp/js/worksheetOptions.js
+++ b/karma-web/src/main/webapp/js/worksheetOptions.js
@@ -354,20 +354,6 @@ function WorksheetOptions(wsId, wsTitle) {
 		return false;
 	}
 
-	function publishToGithub(worksheetId, repo) {
-		var auth = Settings.getInstance().getGithubAuth();
-		if(repo != "disabled" && !repo.endsWith("disabled)")) {
-			if(auth) {
-				showLoading(worksheetId);
-				var githubInfo = generateInfoObject(worksheetId, "", "PublishGithubCommand");
-		        githubInfo["worksheetId"] = worksheetId;
-		        githubInfo["auth"] = auth;
-		        githubInfo["repo"] = repo;
-		        var returned = sendRequest(githubInfo, worksheetId);
-		    }
-	    }
-	}
-
 	function applyModel(event) {
 		console.log("Apply Model: " + worksheetTitle);
 		hideDropdown();

--- a/karma-web/src/main/webapp/js/worksheetOptions.js
+++ b/karma-web/src/main/webapp/js/worksheetOptions.js
@@ -348,27 +348,9 @@ function WorksheetOptions(wsId, wsTitle) {
 	function publishModel(event) {
 		console.log("Publish Model: " + worksheetTitle);
 		hideDropdown();
-		var info = generateInfoObject(worksheetId, "", "GenerateR2RMLModelCommand");
-		info['tripleStoreUrl'] = $('#txtModel_URL').text();
-		showLoading(info["worksheetId"]);
-		var repoUrl = $("#txtGithubUrl_" + worksheetId).text(); 
-		var returned = sendRequest(info, worksheetId,
-			function(data) {
-				var newWorksheetId = worksheetId;
-				$.each(data["elements"], function(i, element) {
-					if(element) {
-						if (element["updateType"] == "PublishR2RMLUpdate") {
-							newWorksheetId = element["worksheetId"];
-						}
-					}
-				});
-
-				var info = generateInfoObject(newWorksheetId, "", "PublishReportCommand");
-				showLoading(newWorksheetId);
-				var returned = sendRequest(info, newWorksheetId, function(json) {
-					publishToGithub(newWorksheetId, repoUrl);
-				});
-			});
+		
+		PublishModelDialog.getInstance().show(worksheetId);
+		
 		return false;
 	}
 

--- a/karma-web/src/main/webapp/tableOptionsDialogs.jsp
+++ b/karma-web/src/main/webapp/tableOptionsDialogs.jsp
@@ -134,8 +134,8 @@ a.icon-remove:hover {
 				  </div>
 				  <div class="modal-body">
 					<div class="form-group">
-							<label for="modelGraphList">RDF Graphs</label>
-							<select id="modelGraphList">
+							<label for="rdfGraphList">RDF Graphs</label>
+							<select id="rdfGraphList">
 		                	</select>
 					</div>
 					<div class="form-group">
@@ -144,13 +144,13 @@ a.icon-remove:hover {
 					</div>	
 					<div class="radio">
 						<label>
-				    		<input type="radio" id="graphReplace_1" name="group1"  value="replace">
+				    		<input type="radio" id="rdfGraphReplace_1" name="group1"  value="replace">
 				    		Replace Existing Data
 			  			</label>
 			  		</div>
 			  		<div class="radio">
 			  			<label>
-				    		<input type="radio" id="graphReplace_2" name="group1" checked value="append">
+				    		<input type="radio" id="rdfGraphReplace_2" name="group1" checked value="append">
 				    		Append
 			  			</label>
 					</div>	
@@ -210,6 +210,53 @@ a.icon-remove:hover {
 						</div>
         			</div>
         			
+					<div class="error" style="display: none">Please enter all values</div>
+				  </div> <!-- /.modal-body -->
+				  <div class="modal-footer">
+				        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+				        <button type="submit" class="btn btn-primary" id="btnSave">Publish</button>
+				  </div> <!-- /.modal-footer -->
+			</div><!-- /.modal-content -->
+		</form>
+	</div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<div class="modal fade" id="publishModelDialog" tabindex="-1">
+  <div class="modal-dialog">
+  		<form class="bs-example bs-example-form" role="form">
+			<div class="modal-content">
+			     <div class="modal-header">
+				      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				       <h4 class="modal-title">Publish Model</h4>
+				  </div>
+				  <div class="modal-body">
+					<div class="form-group">
+							<label for="modelGraphList">RDF Graphs</label>
+							<select id="modelGraphList">
+		                	</select>
+					</div>
+					<div class="form-group">
+						<label id="labelFor_modelSPAQRLGraph" for="modelSPAQRLGraph">Create New Graph</label>
+						<input class="form-control" type="text" id="modelSPAQRLGraph" required value="" maxlength="100">
+					</div>	
+					<div class="radio">
+						<label>
+				    		<input type="radio" id="modelGraphReplace_1" name="group1"  value="replace">
+				    		Replace Existing Data
+			  			</label>
+			  		</div>
+			  		<div class="radio">
+			  			<label>
+				    		<input type="radio" id="modelGraphReplace_2" name="group1" checked value="append">
+				    		Append
+			  			</label>
+					</div>	
+					
+					<div class="form-group">
+						<label id="labelFor_modelURI" for="modelURI">Model URI (Optional)</label>
+						<input class="form-control" type="text" id="modelURI" required value="" maxlength="100">
+					</div>	
+
 					<div class="error" style="display: none">Please enter all values</div>
 				  </div> <!-- /.modal-body -->
 				  <div class="modal-footer">


### PR DESCRIPTION
This introduces a new UI modal when publishing R2RML models.  It allows users to optionally specify a URI for the R2RML model and also choose the RDF graph to use in the repository when publishing the model.  

The default behavior is otherwise maintained.  A graph will be created if none are present. A sane default will be chosen once a graph is present. The R2RML model will be created with a blank node in the repository if no URI is specified.  The user just has one more button to press. 

![image](https://user-images.githubusercontent.com/5325227/54173787-84e97980-4440-11e9-92dd-21ba6fc6dbb1.png)
