### PR TITLE
add https to repository URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 	  <repository>
 		  <id>central</id>
 		  <name>Central Maven Repository</name>
-		  <url>http://repo1.maven.org/maven2/</url>
+		  <url>https://repo1.maven.org/maven2/</url>
 	  </repository>
 
 	  <repository>
@@ -106,7 +106,7 @@
 	  </repository>
       <repository>
         <id>maven2.maven.org</id>
-        <url>http://repo1.maven.org/maven2/</url>
+        <url>https://repo1.maven.org/maven2/</url>
       </repository>
       <repository>
             <id>osgeo</id>


### PR DESCRIPTION
Central Maven Repository requires https connection as of Jan 2020. This update prevents HTTPS 501 errors when compiling web-karma.