### PR TITLE
Fixes Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,17 @@ RUN apk add --no-cache curl tar git
 
 WORKDIR /karma
 
-RUN wget https://mirrors.sonic.net/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+RUN wget https://mirrors.sonic.net/apache/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
 
-RUN tar xzvf apache-maven-3.6.3-bin.tar.gz
+RUN tar xzvf apache-maven-3.9.6-bin.tar.gz
 
 RUN mkdir /karma/Web-Karma
 
 RUN git clone https://github.com/usc-isi-i2/Web-Karma /karma/Web-Karma
 
-RUN cd /karma/Web-Karma && /karma/apache-maven-3.6.3/bin/mvn clean install
+RUN cd /karma/Web-Karma && /karma/apache-maven-3.9.6/bin/mvn clean install
 
-CMD cd /karma/Web-Karma/karma-web && /karma/apache-maven-3.6.3/bin/mvn jetty:run
+CMD cd /karma/Web-Karma/karma-web && /karma/apache-maven-3.9.6/bin/mvn jetty:run
+
+
+# docker build . -t web-karma --ulimit nofile=122880:122880


### PR DESCRIPTION
Docker image build was failing due to old versions and links for maven installation in Dockerfile.

https://github.com/usc-isi-i2/Web-Karma/blob/master/Dockerfile#L6

This PR replaces old maven links with version 3.9.6, now docker image is built with success.

